### PR TITLE
Allow for dialect fall-back

### DIFF
--- a/packages/core/src/Properties.test.ts
+++ b/packages/core/src/Properties.test.ts
@@ -91,6 +91,38 @@ describe('Properties', () => {
         defaultLanguage: 'en-US',
       };
       expect(properties.currentLanguage).toEqual('en-US');
+    });    
+
+    test('returns correct parent language ignoring dialect', () => {
+      const dummyReturn = 'en-US';
+      Storage.prototype.getItem = jest.fn();
+      mocked(localStorage.getItem).mockReturnValueOnce(dummyReturn);
+      properties.config = {
+        availableLanguages: ['en']
+      };
+      expect(properties.currentLanguage).toEqual('en');
+    });  
+
+    test('returns correct parent language ignoring dialect and fallback', () => {
+      const dummyReturn = 'en-US';
+      Storage.prototype.getItem = jest.fn();
+      mocked(localStorage.getItem).mockReturnValueOnce(dummyReturn);
+      properties.config = {
+        availableLanguages: ['en'],
+        fallbackLanguage: 'de'
+      };
+      expect(properties.currentLanguage).toEqual('en');
+    });
+
+    test('returns correct fallback language ignoring non-available dialect and parent', () => {
+      const dummyReturn = 'en-US';
+      Storage.prototype.getItem = jest.fn();
+      mocked(localStorage.getItem).mockReturnValueOnce(dummyReturn);
+      properties.config = {
+        availableLanguages: ['de','it'],
+        fallbackLanguage: 'it'
+      };
+      expect(properties.currentLanguage).toEqual('it');
     });
 
     test('resets current language when missing in availableLanguages', () => {


### PR DESCRIPTION
I believe it's a language code default to fall-back to the parent/root language if a dialect is not available. Sadly, we cannot get this to work in Tolgee-JS at the moment using the Angular integration.