### PR TITLE
fix: loop of svelte getTranslate store

### DIFF
--- a/packages/svelte/src/lib/getTranslate.ts
+++ b/packages/svelte/src/lib/getTranslate.ts
@@ -37,16 +37,18 @@ const getTranslate: GetTranslateType = () => {
       defaultValue: defaultValue,
     });
 
-    // so we have to use also translate method, to get reliable result
-    tolgee
-      .translate({ key: key, params: parameters, noWrap, defaultValue })
-      .then((translated) => {
-        // when the result value is different, we have to update the store and
-        // so return new translate function
-        if (instantTranslated !== translated) {
-          update();
-        }
-      });
+    // if the language was not loaded yet, we have to run the translate method to get a reliable result
+    if (!tolgee.getCachedTranslations().has(tolgee.lang)) {
+      tolgee
+        .translate({ key: key, params: parameters, noWrap, defaultValue })
+        .then((translated) => {
+          // when the result value is different, we have to update the store and
+          // so return new translate function
+          if (instantTranslated !== translated) {
+            update();
+          }
+        });
+    }
 
     return instantTranslated;
   };


### PR DESCRIPTION
I ran into this issue while using the svelte lib of tolgee.

The following code resulted in an endless loop if the provided key was not stored in tolgee already.

Set tolgee provider up like 

```html
<TolgeeProvider config={tolgeeConfig}>
   <slot />
</TolgeeProvider>

```

and using the store like this: 

```jsx
...
const t = getTranslate();
...
<span>{t("my_simple_key")}</span>
```

The fix I came up with is based on the following understanding of the problem:
1. The store does not rely on instant translation because the translations could also not have been loaded yet
2. This lead to an async load of language keys
3. After those are loaded, it is checked if the new value differs from the old one -> somehow the instant method returns "" in my case and the async one the key itself
4. Since those two values differ, the stores update method is triggered again
5. = 2.
