### PR TITLE
feat: add KeyType to TFnType

### DIFF
--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -38,9 +38,9 @@ export type CombinedOptions<T> = TranslateOptions & {
   [key: string]: T | PropType<TranslateOptions>;
 };
 
-export type TFnType<T = DefaultParamType, R = string> = {
-  (key: string, defaultValue?: string, options?: CombinedOptions<T>): R;
-  (key: string, options?: CombinedOptions<T>): R;
+export type TFnType<T = DefaultParamType, R = string, KeyType extends string = string> = {
+  (key: KeyType, defaultValue?: KeyType, options?: CombinedOptions<T>): R;
+  (key: KeyType, options?: CombinedOptions<T>): R;
   (props: TranslateProps<T>): R;
 };
 

--- a/packages/react/src/useTranslate.ts
+++ b/packages/react/src/useTranslate.ts
@@ -4,13 +4,13 @@ import { TFnType, getTranslateProps, DefaultParamType } from '@tolgee/web';
 import { useTranslateInternal } from './useTranslateInternal';
 import { ReactOptions } from './types';
 
-export const useTranslate = (
+export const useTranslate = <KeyType extends string = string>(
   ns?: string[] | string,
   options?: ReactOptions
 ) => {
   const { t: tInternal, isLoading } = useTranslateInternal(ns, options);
 
-  const t: TFnType<DefaultParamType, string> = useCallback(
+  const t: TFnType<DefaultParamType, string, KeyType> = useCallback(
     (...params: any) => {
       // @ts-ignore
       const props = getTranslateProps(...params);


### PR DESCRIPTION
By adding a file like this one in our projects:

```ts
// tolgee.d.ts

import type en from "@/i18n/en.json";

declare module "@tolgee/react" {
  export type TranslationsType = typeof en;

  export type DotNotationEntries<T> =
    T extends object
    ? { [K in keyof T]: `${K & string}${T[K] extends undefined ? "" : T[K] extends object ? `.${DotNotationEntries<T[K]>}` : ""}` }[keyof T]
    : "";

  export type TranslationKeys = DotNotationEntries<TranslationsType>;
}
```

![image](https://user-images.githubusercontent.com/35939574/227766261-54db6f9a-33f4-4650-b691-8f106b25602b.png)


and patching two functions in your codebase, we can have autocomplete working.

![image](https://user-images.githubusercontent.com/35939574/227766040-d660d35c-7c5f-49dd-adba-3ebf9c741e9f.png)

Since it's an optional argument, it doesn't impact existing users, but they also don't get it for free: you need to create an additional file.