### PR TITLE
feat: globally typeable key in tolgee core

### DIFF
--- a/packages/core/src/TolgeeCore.ts
+++ b/packages/core/src/TolgeeCore.ts
@@ -1,6 +1,13 @@
 import { Controller } from './Controller/Controller';
 import { combineOptions } from './Controller/State/initState';
-import { TolgeeOptions, TolgeePlugin, DevCredentials } from './types';
+import {
+  TolgeeOptions,
+  TolgeePlugin,
+  DevCredentials,
+  TFnType,
+  DefaultParamType,
+  TranslationKey,
+} from './types';
 
 const createTolgee = (options: TolgeeOptions) => {
   const controller = Controller({
@@ -214,7 +221,10 @@ const createTolgee = (options: TolgeeOptions) => {
   return tolgee;
 };
 
-export type TolgeeInstance = ReturnType<typeof createTolgee>;
+export type TolgeeInstance = Omit<ReturnType<typeof createTolgee>, 't'> & {
+  // enabling generics (when inferred they are lost)
+  t: TFnType<DefaultParamType, string, TranslationKey>;
+};
 
 export type TolgeeChainer = {
   /**

--- a/packages/core/src/types/general.ts
+++ b/packages/core/src/types/general.ts
@@ -2,7 +2,9 @@ export type FallbackGeneral = undefined | false | string | string[];
 
 export type NsType = string;
 
-export type KeyType = string;
+// This prevents typescript to optimize this to 'string'
+// this type needs to be overritable everywhere
+export type TranslationKey = string & Record<never, never>;
 
 export type NsFallback = undefined | NsType | NsType[];
 
@@ -22,8 +24,11 @@ export type TranslateOptions = {
   orEmpty?: boolean;
 };
 
-export type TranslateProps<T = DefaultParamType> = {
-  key: KeyType;
+export type TranslateProps<
+  T = DefaultParamType,
+  K extends string = TranslationKey
+> = {
+  key: K;
   defaultValue?: string;
   params?: TranslateParams<T>;
 } & TranslateOptions;
@@ -38,10 +43,14 @@ export type CombinedOptions<T> = TranslateOptions & {
   [key: string]: T | PropType<TranslateOptions>;
 };
 
-export type TFnType<T = DefaultParamType, R = string> = {
-  (key: string, defaultValue?: string, options?: CombinedOptions<T>): R;
-  (key: string, options?: CombinedOptions<T>): R;
-  (props: TranslateProps<T>): R;
+export type TFnType<
+  T = DefaultParamType,
+  R = string,
+  K extends string = TranslationKey
+> = {
+  (key: K, defaultValue?: string, options?: CombinedOptions<T>): R;
+  (key: K, options?: CombinedOptions<T>): R;
+  (props: TranslateProps<T, K>): R;
 };
 
 export type KeyAndNamespacesInternal = Pick<

--- a/packages/ngx/projects/ngx-tolgee/src/lib/t.component.ts
+++ b/packages/ngx/projects/ngx-tolgee/src/lib/t.component.ts
@@ -8,14 +8,14 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TranslateService } from './translate.service';
-import { TranslateParams } from '@tolgee/web';
+import { TranslateParams, TranslationKey } from '@tolgee/web';
 
 @Component({
   selector: '[t]',
   template: ``,
 })
 export class TComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() key: string;
+  @Input() key: TranslationKey;
   @Input() ns: string;
   @Input() params?: TranslateParams<any>;
   @Input() default?: string;

--- a/packages/ngx/projects/ngx-tolgee/src/lib/translate.pipe.ts
+++ b/packages/ngx/projects/ngx-tolgee/src/lib/translate.pipe.ts
@@ -1,7 +1,7 @@
 import { OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { TranslateService } from './translate.service';
 import { Subscription } from 'rxjs';
-import { getTranslateProps, TFnType, TranslateProps } from '@tolgee/web';
+import { getTranslateProps, TFnType, TranslateProps, TranslationKey } from '@tolgee/web';
 
 @Pipe({
   name: 'translate',
@@ -19,7 +19,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     this.unsubscribe();
   }
 
-  readonly transform: TFnType<string> = (...args) => {
+  readonly transform: TFnType<string, string, TranslationKey> = (...args) => {
     // @ts-ignore
     const params = getTranslateProps(...args);
     const { key } = params;

--- a/packages/ngx/projects/ngx-tolgee/src/lib/translate.service.ts
+++ b/packages/ngx/projects/ngx-tolgee/src/lib/translate.service.ts
@@ -7,6 +7,7 @@ import {
   ListenerEvent,
   TFnType,
   TolgeeInstance,
+  TranslationKey,
 } from '@tolgee/web';
 import { TOLGEE_INSTANCE } from './tolgee-instance-token';
 
@@ -42,7 +43,7 @@ export class TranslateService implements OnDestroy {
   /**
    * Returns translation asynchronously, this method always return
    */
-  readonly translate: TFnType<DefaultParamType, Observable<string>> = (
+  readonly translate: TFnType<DefaultParamType, Observable<string>, TranslationKey> = (
     ...args
   ) => {
     // @ts-ignore
@@ -73,7 +74,7 @@ export class TranslateService implements OnDestroy {
    * Instantly returns translated value. May return undefined or outdated value.
    * Use only when you cannot use translate.
    */
-  public readonly instant: TFnType = (...args) => {
+  public readonly instant: TFnType<DefaultParamType, string, TranslationKey> = (...args) => {
     // @ts-ignore
     const params = getTranslateProps(...args);
     return this.tolgee.t(params);

--- a/packages/react/src/T.tsx
+++ b/packages/react/src/T.tsx
@@ -1,15 +1,15 @@
-import { NsType, TranslateParams } from '@tolgee/web';
+import { NsType, TranslateParams, TranslationKey } from '@tolgee/web';
 import React, { FunctionComponent } from 'react';
 import { addReactKeys, wrapTagHandlers } from './tagsTools';
-
 import { ParamsTags } from './types';
+
 import { useTranslateInternal } from './useTranslateInternal';
 
 type TProps = {
   params?: TranslateParams<ParamsTags>;
   children?: string;
   noWrap?: boolean;
-  keyName?: string;
+  keyName?: TranslationKey;
   ns?: NsType;
   defaultValue?: string;
 };

--- a/packages/react/src/T.tsx
+++ b/packages/react/src/T.tsx
@@ -1,27 +1,41 @@
 import { NsType, TranslateParams, TranslationKey } from '@tolgee/web';
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { addReactKeys, wrapTagHandlers } from './tagsTools';
 import { ParamsTags } from './types';
 
 import { useTranslateInternal } from './useTranslateInternal';
 
-type TProps = {
+type PropsWithKeyName = {
   params?: TranslateParams<ParamsTags>;
   children?: string;
   noWrap?: boolean;
-  keyName?: TranslationKey;
+  keyName: TranslationKey;
   ns?: NsType;
   defaultValue?: string;
 };
 
-export const T: FunctionComponent<TProps> = (props: TProps) => {
-  const key = props.keyName || props.children;
+type PropsWithoutKeyName = {
+  params?: TranslateParams<ParamsTags>;
+  children: TranslationKey;
+  noWrap?: boolean;
+  ns?: NsType;
+  defaultValue?: string;
+};
+
+interface TInterface {
+  (props: PropsWithKeyName): JSX.Element;
+  (props: PropsWithoutKeyName): JSX.Element;
+}
+
+export const T: TInterface = (props) => {
+  const key = (props as PropsWithKeyName).keyName || props.children;
   if (key === undefined) {
     // eslint-disable-next-line no-console
     console.error('T component: keyName not defined');
   }
   const defaultValue =
-    props.defaultValue || (props.keyName ? props.children : undefined);
+    props.defaultValue ||
+    ((props as PropsWithKeyName).keyName ? props.children : undefined);
 
   const { t } = useTranslateInternal();
 

--- a/packages/react/src/useTranslate.ts
+++ b/packages/react/src/useTranslate.ts
@@ -1,16 +1,26 @@
 import { useCallback } from 'react';
-import { TFnType, getTranslateProps, DefaultParamType } from '@tolgee/web';
+import {
+  TFnType,
+  getTranslateProps,
+  DefaultParamType,
+  TranslationKey,
+} from '@tolgee/web';
 
 import { useTranslateInternal } from './useTranslateInternal';
 import { ReactOptions } from './types';
 
+type UseTranslateResult = {
+  t: TFnType<DefaultParamType, string, TranslationKey>;
+  isLoading: boolean;
+};
+
 export const useTranslate = (
   ns?: string[] | string,
   options?: ReactOptions
-) => {
+): UseTranslateResult => {
   const { t: tInternal, isLoading } = useTranslateInternal(ns, options);
 
-  const t: TFnType<DefaultParamType, string> = useCallback(
+  const t = useCallback(
     (...params: any) => {
       // @ts-ignore
       const props = getTranslateProps(...params);

--- a/packages/svelte/src/lib/T.svelte
+++ b/packages/svelte/src/lib/T.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import type { NsType } from '@tolgee/web';
+    import type { NsType, TranslationKey } from '@tolgee/web';
   import getTranslateInternal from './getTranslateInternal';
 
-  export let keyName: string;
+  export let keyName: TranslationKey;
   export let params: Record<string, unknown> | undefined = undefined;
   export let noWrap = false;
   export let defaultValue = undefined;

--- a/packages/svelte/src/lib/getTranslate.ts
+++ b/packages/svelte/src/lib/getTranslate.ts
@@ -1,8 +1,19 @@
 import { derived, type Readable } from 'svelte/store';
-import { getTranslateProps, type NsFallback, type TFnType } from '@tolgee/web';
+import {
+  getTranslateProps,
+  type DefaultParamType,
+  type NsFallback,
+  type TFnType,
+  type TranslationKey,
+} from '@tolgee/web';
 import getTranslateInternal from './getTranslateInternal';
 
-const getTranslate = (ns?: NsFallback) => {
+type UseTranslateResult = {
+  t: Readable<TFnType<DefaultParamType, string, TranslationKey>>;
+  isLoading: Readable<boolean>;
+};
+
+const getTranslate = (ns?: NsFallback): UseTranslateResult => {
   const { t: tInternal, isLoading } = getTranslateInternal(ns);
 
   const t = derived(tInternal, (value) => (...params) => {

--- a/packages/vue/src/T.ts
+++ b/packages/vue/src/T.ts
@@ -1,11 +1,16 @@
-import { NsType, TranslateParams, TranslateProps } from '@tolgee/web';
+import {
+  NsType,
+  TranslateParams,
+  TranslateProps,
+  TranslationKey,
+} from '@tolgee/web';
 import { defineComponent, PropType } from 'vue';
 import { useTranslateInternal } from './useTranslateInternal';
 
 export const T = defineComponent({
   name: 'T',
   props: {
-    keyName: { type: String, required: true },
+    keyName: { type: String as PropType<TranslationKey>, required: true },
     params: Object as PropType<TranslateParams>,
     defaultValue: String as PropType<string>,
     noWrap: {

--- a/packages/vue/src/VueTolgee.ts
+++ b/packages/vue/src/VueTolgee.ts
@@ -4,6 +4,7 @@ import {
   TolgeeInstance,
   TFnType,
   DefaultParamType,
+  TranslationKey,
 } from '@tolgee/web';
 
 type Options = {
@@ -44,7 +45,7 @@ export const VueTolgee = {
 
 declare module 'vue' {
   export interface ComponentCustomProperties {
-    $t: TFnType<DefaultParamType, string>;
+    $t: TFnType<DefaultParamType, string, TranslationKey>;
     $tolgee: TolgeeInstance;
   }
 }

--- a/packages/vue/src/useTranslate.ts
+++ b/packages/vue/src/useTranslate.ts
@@ -3,11 +3,17 @@ import {
   NsFallback,
   TFnType,
   getTranslateProps,
+  TranslationKey,
 } from '@tolgee/web';
 import { computed, Ref } from 'vue';
 import { useTranslateInternal } from './useTranslateInternal';
 
-export const useTranslate = (namespaces?: NsFallback) => {
+type UseTranslateResult = {
+  t: Ref<TFnType<DefaultParamType, string, TranslationKey>>;
+  isLoading: Ref<boolean>;
+};
+
+export const useTranslate = (namespaces?: NsFallback): UseTranslateResult => {
   const { t: tInternal, isLoading } = useTranslateInternal(namespaces);
 
   const t: Ref<TFnType<DefaultParamType, string>> = computed(


### PR DESCRIPTION
Tolgee core now uses `TranslationKey` type which can be overriten globally to type translation keys.