### PR TITLE
fix: don't pass empty children to interpolated elements

### DIFF
--- a/packages/react/src/__integration/T.spec.tsx
+++ b/packages/react/src/__integration/T.spec.tsx
@@ -36,6 +36,13 @@ describe('T component integration', () => {
         <div data-testid="with_tags">
           <T keyName="with_tags" params={{ b: <b />, i: <i /> }} />
         </div>
+        <div data-testid="with_empty_tag">
+          <T
+            keyName="with_empty_tag"
+            params={{ br: <br /> }}
+            defaultValue="Here is empty<br></br>tag"
+          />
+        </div>
         <div data-testid="with_tag">
           <T
             keyName="with_tag"
@@ -112,6 +119,13 @@ describe('T component integration', () => {
       'Tento <b>text <i>je</i> formátovaný</b>'
     );
     expect(screen.queryByTestId('with_tags')).toHaveAttribute('_tolgee');
+  });
+
+  it('works with empty tag', () => {
+    expect(screen.queryByTestId('with_empty_tag')).toContainHTML(
+      'Here is empty<br />tag'
+    );
+    expect(screen.queryByTestId('with_empty_tag')).toHaveAttribute('_tolgee');
   });
 
   it('works with tag as function', () => {

--- a/packages/react/src/__integration/T.spec.tsx
+++ b/packages/react/src/__integration/T.spec.tsx
@@ -43,6 +43,15 @@ describe('T component integration', () => {
             defaultValue="Here is empty<br></br>tag"
           />
         </div>
+        <div data-testid="with_children_conflict">
+          <T
+            keyName="with_children_conflict"
+            params={{
+              b: <b>should</b>,
+            }}
+            defaultValue="This <b>shouldn't</b> be here"
+          />
+        </div>
         <div data-testid="with_tag">
           <T
             keyName="with_tag"
@@ -126,6 +135,15 @@ describe('T component integration', () => {
       'Here is empty<br />tag'
     );
     expect(screen.queryByTestId('with_empty_tag')).toHaveAttribute('_tolgee');
+  });
+
+  it("won't pass children if the element already has children", () => {
+    expect(screen.queryByTestId('with_children_conflict')).toContainHTML(
+      'This <b>should</b> be here'
+    );
+    expect(screen.queryByTestId('with_children_conflict')).toHaveAttribute(
+      '_tolgee'
+    );
   });
 
   it('works with tag as function', () => {

--- a/packages/react/src/tagsTools.tsx
+++ b/packages/react/src/tagsTools.tsx
@@ -20,7 +20,7 @@ export const wrapTagHandlers = (
     } else if (React.isValidElement(value as any)) {
       const el = value as React.ReactElement;
       result[key] = (chunk: any) => {
-        return chunk?.length
+        return el.props.children === undefined && chunk?.length
           ? React.cloneElement(el, {}, addReactKeys(chunk))
           : React.cloneElement(el);
       };

--- a/packages/react/src/tagsTools.tsx
+++ b/packages/react/src/tagsTools.tsx
@@ -20,9 +20,9 @@ export const wrapTagHandlers = (
     } else if (React.isValidElement(value as any)) {
       const el = value as React.ReactElement;
       result[key] = (chunk: any) => {
-        return !el.props.children
-          ? React.cloneElement(el)
-          : React.cloneElement(el, {}, addReactKeys(chunk));
+        return chunk?.length
+          ? React.cloneElement(el, {}, addReactKeys(chunk))
+          : React.cloneElement(el);
       };
     } else {
       result[key] = value;

--- a/packages/react/src/tagsTools.tsx
+++ b/packages/react/src/tagsTools.tsx
@@ -20,7 +20,7 @@ export const wrapTagHandlers = (
     } else if (React.isValidElement(value as any)) {
       const el = value as React.ReactElement;
       result[key] = (chunk: any) => {
-        return el.props.children !== undefined
+        return !el.props.children
           ? React.cloneElement(el)
           : React.cloneElement(el, {}, addReactKeys(chunk));
       };

--- a/testapps/react/src/TranslationMethods.tsx
+++ b/testapps/react/src/TranslationMethods.tsx
@@ -67,6 +67,19 @@ export const TranslationMethods = () => {
         </div>
 
         <div>
+          <h1>T component with br tag</h1>
+          <div data-cy="translationWithTags">
+            <T
+              keyName="this_is_a_key_with_br_tag"
+              params={{
+                br: <br />,
+              }}
+              defaultValue="Key with br<br></br>tag"
+            />
+          </div>
+        </div>
+
+        <div>
           <h1>t function without default</h1>
           <div>{t('this_is_a_key')}</div>
         </div>


### PR DESCRIPTION
Prevent passing empty children to interpolated elements. This way users can use self closing elements in non-self-closing way, which is supported by format.js (`<br></br>`).

Previously react was trhowing an error that `<br />` can't have children.