### PR TITLE
move registry refresh out of the observer loop

### DIFF
--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -104,8 +104,8 @@ export function GeneralObserver() {
             break;
         }
         handleNodes(result);
-        elementRegistry.refreshAll();
       }
+      elementRegistry.refreshAll();
     });
 
     const targetElement = options.targetElement || document.body;


### PR DESCRIPTION
This resolves the $O(n^2)$ problem in the observer and vastly boosts the initialization performance. 

I have noticed no drawbacks yet.