### PR TITLE
fix: export props and return types

### DIFF
--- a/packages/react/src/T.tsx
+++ b/packages/react/src/T.tsx
@@ -5,28 +5,27 @@ import { ParamsTags } from './types';
 
 import { useTranslateInternal } from './useTranslateInternal';
 
-type PropsWithKeyName = {
+interface PropsBase {
   params?: TranslateParams<ParamsTags>;
-  children?: string;
   noWrap?: boolean;
-  keyName: TranslationKey;
   ns?: NsType;
   defaultValue?: string;
   language?: string;
-};
+}
 
-type PropsWithoutKeyName = {
-  params?: TranslateParams<ParamsTags>;
+interface PropsWithKeyName extends PropsBase {
+  children?: string;
+  keyName: TranslationKey;
+}
+
+interface PropsWithoutKeyName extends PropsBase {
   children: TranslationKey;
-  noWrap?: boolean;
-  ns?: NsType;
-  defaultValue?: string;
-  language?: string;
-};
+}
+
+export type TProps = PropsWithKeyName | PropsWithoutKeyName;
 
 interface TInterface {
-  (props: PropsWithKeyName): JSX.Element;
-  (props: PropsWithoutKeyName): JSX.Element;
+  (props: TProps): JSX.Element;
 }
 
 export const T: TInterface = (props) => {

--- a/packages/react/src/TolgeeProvider.tsx
+++ b/packages/react/src/TolgeeProvider.tsx
@@ -10,14 +10,14 @@ export const TolgeeProviderContext = React.createContext<
   TolgeeReactContext | undefined
 >(undefined);
 
-type Props = {
+export interface TolgeeProviderProps {
   children?: React.ReactNode;
   tolgee: TolgeeInstance;
   options?: ReactOptions;
   fallback?: React.ReactNode;
-};
+}
 
-export const TolgeeProvider: React.FC<Props> = ({
+export const TolgeeProvider: React.FC<TolgeeProviderProps> = ({
   tolgee,
   options,
   children,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,10 @@
-export { useTranslate } from './useTranslate';
-export { TolgeeProvider, TolgeeProviderContext } from './TolgeeProvider';
-export { T } from './T';
+export { useTranslate, UseTranslateResult } from './useTranslate';
+export {
+  TolgeeProvider,
+  TolgeeProviderProps,
+  TolgeeProviderContext,
+} from './TolgeeProvider';
+export { T, TProps } from './T';
 export { useTolgee } from './useTolgee';
 export { GlobalContextPlugin } from './GlobalContextPlugin';
 export { useTolgeeSSR } from './useTolgeeSSR';

--- a/packages/react/src/useTranslate.ts
+++ b/packages/react/src/useTranslate.ts
@@ -9,10 +9,10 @@ import {
 import { useTranslateInternal } from './useTranslateInternal';
 import { ReactOptions } from './types';
 
-type UseTranslateResult = {
+export interface UseTranslateResult {
   t: TFnType<DefaultParamType, string, TranslationKey>;
   isLoading: boolean;
-};
+}
 
 export const useTranslate = (
   ns?: string[] | string,


### PR DESCRIPTION
Hello,

It's a good practice with react to export Props types and Return types for Components and hooks.
It's more simple when we want reuse theses types to get them from packages than rely on typescript utility types like `ReturnType` and `Parameters`.

Best regards