### PR TITLE
fix: remove unused window check, as onMount only runs client side

### DIFF
--- a/packages/svelte/src/lib/TolgeeProvider.svelte
+++ b/packages/svelte/src/lib/TolgeeProvider.svelte
@@ -12,14 +12,12 @@
     tolgee,
   } as TolgeeSvelteContext);
 
-  if (typeof window !== 'undefined') {
-    onMount(() => {
-      tolgee.run().finally(() => {
-        isLoading = false
-      })
-    });
-    onDestroy(tolgee.stop);
-  }
+  onMount(() => {
+    tolgee.run().finally(() => {
+      isLoading = false
+    })
+  });
+  onDestroy(tolgee.stop);
 </script>
 
 {#if !isLoading }


### PR DESCRIPTION
I just checked the svelte docs again and onMount / onDestroy only run [client side](https://svelte.dev/docs/svelte#onmount).
I found this out while playing with svelte 5 preview (svelte@next) as it throws an error failing to ssr the page.
Removing the check does not change the behavior, so I think it can just be removed