### PR TITLE
refreshAll debounce

### DIFF
--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -33,7 +33,7 @@ export function ElementRegistry(
     },
     options,
   });
-  let refreshAllTimeout: number | null = null;
+  let refreshAllTimeout: null | number | ReturnType<typeof setTimeout> = null;
 
   function isRestricted(element: Element) {
     const restrictedElements = options.restrictedElements;

--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -33,6 +33,7 @@ export function ElementRegistry(
     },
     options,
   });
+  let refreshAllTimeout: number | null = null;
 
   function isRestricted(element: Element) {
     const restrictedElements = options.restrictedElements;
@@ -102,6 +103,13 @@ export function ElementRegistry(
     },
 
     forEachElement: elementStore.forEachElement,
+
+    refreshAllLater() {
+      if (refreshAllTimeout) {
+        clearTimeout(refreshAllTimeout);
+      }
+      refreshAllTimeout = setTimeout(this.refreshAll, 500);
+    },
 
     refreshAll() {
       elementStore.forEachElement((element, meta) => {

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -110,7 +110,7 @@ export function GeneralObserver() {
         }
         handleNodes(result);
       }
-      elementRegistry.refreshAll();
+      elementRegistry.refreshAllLater();
     });
 
     const targetElement = options.targetElement || document.body;


### PR DESCRIPTION
Add a debouncer to `refreshAll` to decouple it off the MutationObserver hot path, to hopefully bring better performance.