### PR TITLE
Improve DOM Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ node_modules
 .gradle
 .idea
 **/.turbo
+**/'.turbo'
 .pnpm-store
 .VERSION

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "@commitlint/config-conventional"
     ]
   },
-  "packageManager": "pnpm@7.9.4",
+  "packageManager": "pnpm@8.6.12+sha256.3ed40ffc6cbb00790ab325e9d3ff5517a3ed5b763ec53a411707b1702a411174",
   "dependencies": {
     "ts-jest": "^29.0.3"
   },

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -61,11 +61,6 @@ export type WrapperWrapProps = Pick<
 export type WrapperWrapFunction = (props: WrapperWrapProps) => string;
 export type WrapperUnwrapFunction = (text: string) => Unwrapped;
 
-export type WrapperAttributeXPathGetter = (props: {
-  tag: string;
-  attribute: string;
-}) => string;
-
 export type HighlightInterface = (key?: string, ns?: NsFallback) => Highlighter;
 export type FindPositionsInterface = (
   key?: string,
@@ -118,9 +113,7 @@ export type DevCredentials =
 export type WrapperMiddleware = {
   unwrap: WrapperUnwrapFunction;
   wrap: WrapperWrapFunction;
-  getTextXPath: () => string;
   testTextNode: (node: Text) => boolean;
-  getAttributeXPath: WrapperAttributeXPathGetter;
   testAttribute: (node: Attr) => boolean;
 };
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -119,7 +119,9 @@ export type WrapperMiddleware = {
   unwrap: WrapperUnwrapFunction;
   wrap: WrapperWrapFunction;
   getTextXPath: () => string;
+  testTextNode: (node: Text) => boolean;
   getAttributeXPath: WrapperAttributeXPathGetter;
+  testAttribute: (node: Attr) => boolean;
 };
 
 export type FormatterMiddlewareFormatParams = {

--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -3,6 +3,7 @@ import { KeyAndParams, TranslationOnClick } from '@tolgee/core';
 import {
   TOLGEE_RESTRICT_ATTRIBUTE,
   TOLGEE_ATTRIBUTE_NAME,
+  TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE,
 } from '../../constants';
 import { ElementMeta, NodeMeta, TolgeeElement } from '../../types';
 
@@ -97,6 +98,28 @@ export function ElementRegistry(
     },
 
     forEachElement: elementStore.forEachElement,
+
+    cleanupLingeringKeyAttributes() {
+      elementStore.forEachElement((element, meta) => {
+        if (meta.preventClean) {
+          return;
+        }
+        for (const [node] of meta.nodes) {
+          if (node.nodeType === Node.ATTRIBUTE_NODE) {
+            const attr = node as Attr;
+            if (
+              attr.name === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE &&
+              attr.ownerElement === null
+            ) {
+              meta.nodes.delete(attr);
+            }
+          }
+        }
+        if (meta.nodes.size === 0) {
+          cleanElement(element, meta);
+        }
+      });
+    },
 
     cleanupRemovedNodes(removedNodes: Set<Node>) {
       elementStore.forEachElement((element, meta) => {

--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -9,7 +9,7 @@ import { ElementMeta, NodeMeta, TolgeeElement } from '../../types';
 import { ElementHighlighter } from './ElementHighlighter';
 import { initElementMeta } from './ElementMeta';
 import { ElementStoreType } from './ElementStore';
-import { compareDescriptors, nodeContains } from './helpers';
+import { compareDescriptors } from './helpers';
 import { MouseEventHandler } from './MouseEventHandler';
 
 export function ElementRegistry(
@@ -42,7 +42,10 @@ export function ElementRegistry(
     );
   }
 
-  function cleanElementInactiveNodes(meta: ElementMeta, removedNodes: Set<Node>) {
+  function cleanElementInactiveNodes(
+    meta: ElementMeta,
+    removedNodes: Set<Node>
+  ) {
     for (const [key] of meta.nodes) {
       if (removedNodes.has(key)) {
         meta.nodes.delete(key);

--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -42,18 +42,10 @@ export function ElementRegistry(
     );
   }
 
-  function cleanElementInactiveNodes(meta: ElementMeta) {
-    meta.nodes = new Map(getActiveNodes(meta));
-  }
-
-  function getTargetElement() {
-    return options.targetElement || document.body;
-  }
-
-  function* getActiveNodes(meta: ElementMeta) {
-    for (const [node, nodeMeta] of meta.nodes.entries()) {
-      if (nodeContains(getTargetElement(), node)) {
-        yield [node, nodeMeta] as const;
+  function cleanElementInactiveNodes(meta: ElementMeta, removedNodes: Set<Node>) {
+    for (const [key] of meta.nodes) {
+      if (removedNodes.has(key)) {
+        meta.nodes.delete(key);
       }
     }
   }
@@ -103,12 +95,12 @@ export function ElementRegistry(
 
     forEachElement: elementStore.forEachElement,
 
-    refreshAll() {
+    cleanupRemovedNodes(removedNodes: Set<Node>) {
       elementStore.forEachElement((element, meta) => {
         if (meta.preventClean) {
           return;
         }
-        cleanElementInactiveNodes(meta);
+        cleanElementInactiveNodes(meta, removedNodes);
         if (meta.nodes.size === 0) {
           cleanElement(element, meta);
         }

--- a/packages/web/src/observers/general/ElementRegistry.ts
+++ b/packages/web/src/observers/general/ElementRegistry.ts
@@ -103,8 +103,10 @@ export function ElementRegistry(
         if (meta.preventClean) {
           return;
         }
-        cleanElementInactiveNodes(meta, removedNodes);
-        if (meta.nodes.size === 0) {
+        if (!removedNodes.has(element)) {
+          cleanElementInactiveNodes(meta, removedNodes);
+        }
+        if (removedNodes.has(element) || meta.nodes.size === 0) {
           cleanElement(element, meta);
         }
       });

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -200,9 +200,16 @@ export function GeneralObserver() {
     handleKeyAttribute(targetElement, true);
     handleNodes(nodeHandler.handleChildList([targetElement]));
 
+    const monitorAttributeList = new Set<string>();
+    monitorAttributeList.add(TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE);
+    Object.values(options.tagAttributes).forEach((attrs) =>
+      attrs.forEach((attr) => monitorAttributeList.add(attr.toLowerCase()))
+    );
+
     // then observe for changes
     observer.observe(targetElement, {
       attributes: true,
+      attributeFilter: [...monitorAttributeList],
       childList: true,
       subtree: true,
       characterData: true,

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -15,12 +15,7 @@ import { DomHelper } from './DomHelper';
 import { initNodeMeta } from './ElementMeta';
 import { ElementRegistry, ElementRegistryInstance } from './ElementRegistry';
 import { ElementStore } from './ElementStore';
-import {
-  compareDescriptors,
-  getNodeText,
-  setNodeText,
-  xPathEvaluate,
-} from './helpers';
+import { compareDescriptors, getNodeText, setNodeText } from './helpers';
 import { NodeHandler } from './NodeHandler';
 
 type RunningInstance = {
@@ -84,8 +79,14 @@ export function GeneralObserver() {
         }
       }
 
-      const walker = document.createTreeWalker(node, NodeFilter.SHOW_ATTRIBUTE, f =>
-        (f as Attr).name === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP);
+      const walker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_ATTRIBUTE,
+        (f) =>
+          (f as Attr).name === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_SKIP
+      );
       while (walker.nextNode()) {
         const attr = walker.currentNode as Attr;
         const parentElement = domHelper.getSuitableParent(attr as Node);
@@ -102,11 +103,16 @@ export function GeneralObserver() {
         return;
       }
 
-      let removedNodes = mutationsList.filter(m => m.type === 'childList').flatMap(m => Array.from(m.removedNodes));
-      let removedNodesSet = new Set(removedNodes);
+      const removedNodes = mutationsList
+        .filter((m) => m.type === 'childList')
+        .flatMap((m) => Array.from(m.removedNodes));
+      const removedNodesSet = new Set(removedNodes);
 
       for (const node of removedNodes) {
-        const treeWalker = document.createTreeWalker(node);
+        const treeWalker = document.createTreeWalker(
+          node,
+          NodeFilter.SHOW_ATTRIBUTE | NodeFilter.SHOW_TEXT
+        );
         while (treeWalker.nextNode()) {
           removedNodesSet.add(treeWalker.currentNode);
         }
@@ -116,7 +122,7 @@ export function GeneralObserver() {
         elementRegistry.cleanupRemovedNodes(removedNodesSet);
       }
 
-      let result: (Attr | Text)[] = [];
+      const result: (Attr | Text)[] = [];
       for (const mutation of mutationsList) {
         switch (mutation.type) {
           case 'characterData':

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -177,6 +177,11 @@ export function GeneralObserver() {
                 .handleChildList(Array.from(mutation.addedNodes))
                 .forEach((t) => result.add(t));
             }
+            if (mutation.removedNodes.length > 0) {
+              nodeHandler
+                .handleChildList(Array.from(mutation.removedNodes))
+                .forEach((t) => result.delete(t));
+            }
             break;
 
           case 'attributes':

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -172,9 +172,11 @@ export function GeneralObserver() {
 
           case 'childList':
             handleKeyAttribute(mutation.target, true);
-            nodeHandler
-              .handleChildList(mutation.target)
-              .forEach((t) => result.add(t));
+            if (mutation.addedNodes.length > 0) {
+              nodeHandler
+                .handleChildList(Array.from(mutation.addedNodes))
+                .forEach((t) => result.add(t));
+            }
             break;
 
           case 'attributes':
@@ -182,7 +184,7 @@ export function GeneralObserver() {
               handleKeyAttribute(mutation.target, false);
             }
             nodeHandler
-              .handleAttributes(mutation.target)
+              .handleAttributes(mutation.target, false)
               .forEach((t) => result.add(t));
             break;
         }
@@ -196,7 +198,7 @@ export function GeneralObserver() {
 
     // initially go through all elements
     handleKeyAttribute(targetElement, true);
-    handleNodes(nodeHandler.handleChildList(targetElement));
+    handleNodes(nodeHandler.handleChildList([targetElement]));
 
     // then observe for changes
     observer.observe(targetElement, {

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -75,7 +75,7 @@ export function GeneralObserver() {
       });
     }
 
-    function handleKeyAttribute(node: Node) {
+    function handleKeyAttribute(node: Node, includeChild: boolean) {
       if (node.nodeType === Node.ATTRIBUTE_NODE) {
         const attr = node as Attr;
         if (attr.name === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE) {
@@ -92,6 +92,10 @@ export function GeneralObserver() {
         if (attr) {
           handleKeyAttributeAttr(attr);
         }
+      }
+
+      if (!includeChild) {
+        return;
       }
 
       const walker = document.createTreeWalker(
@@ -167,7 +171,7 @@ export function GeneralObserver() {
             break;
 
           case 'childList':
-            handleKeyAttribute(mutation.target);
+            handleKeyAttribute(mutation.target, true);
             nodeHandler
               .handleChildList(mutation.target)
               .forEach((t) => result.add(t));
@@ -175,7 +179,7 @@ export function GeneralObserver() {
 
           case 'attributes':
             if (mutation.attributeName === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE) {
-              handleKeyAttribute(mutation.target);
+              handleKeyAttribute(mutation.target, false);
             }
             nodeHandler
               .handleAttributes(mutation.target)
@@ -191,7 +195,7 @@ export function GeneralObserver() {
     elementRegistry.run(mouseHighlight);
 
     // initially go through all elements
-    handleKeyAttribute(targetElement);
+    handleKeyAttribute(targetElement, true);
     handleNodes(nodeHandler.handleChildList(targetElement));
 
     // then observe for changes

--- a/packages/web/src/observers/general/GeneralObserver.ts
+++ b/packages/web/src/observers/general/GeneralObserver.ts
@@ -81,18 +81,20 @@ export function GeneralObserver() {
 
       const walker = document.createTreeWalker(
         node,
-        NodeFilter.SHOW_ATTRIBUTE,
-        (f) =>
-          (f as Attr).name === TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE
+        NodeFilter.SHOW_ELEMENT,
+        (e) =>
+          (e as Element).hasAttribute(TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE)
             ? NodeFilter.FILTER_ACCEPT
             : NodeFilter.FILTER_SKIP
       );
       while (walker.nextNode()) {
-        const attr = walker.currentNode as Attr;
-        const parentElement = domHelper.getSuitableParent(attr as Node);
-        elementRegistry.register(parentElement, attr as Node, {
+        const attr = (walker.currentNode as Element).getAttributeNode(
+          TOLGEE_WRAPPED_ONLY_DATA_ATTRIBUTE
+        ) as Node;
+        const parentElement = domHelper.getSuitableParent(attr);
+        elementRegistry.register(parentElement, attr, {
           oldTextContent: '',
-          keys: [{ key: getNodeText(attr as Node)! }],
+          keys: [{ key: getNodeText(attr)! }],
           keyAttributeOnly: true,
         });
       }
@@ -111,10 +113,17 @@ export function GeneralObserver() {
       for (const node of removedNodes) {
         const treeWalker = document.createTreeWalker(
           node,
-          NodeFilter.SHOW_ATTRIBUTE | NodeFilter.SHOW_TEXT
+          NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT
         );
         while (treeWalker.nextNode()) {
-          removedNodesSet.add(treeWalker.currentNode);
+          const currentNode = treeWalker.currentNode;
+          if (currentNode.nodeType === Node.ELEMENT_NODE) {
+            const element = currentNode as Element;
+            for (let i = 0; i < element.attributes.length; i++) {
+              removedNodesSet.add(element.attributes[i]);
+            }
+          }
+          removedNodesSet.add(currentNode);
         }
       }
 

--- a/packages/web/src/observers/general/NodeHandler.ts
+++ b/packages/web/src/observers/general/NodeHandler.ts
@@ -1,5 +1,4 @@
 import { ObserverOptionsInternal, WrapperMiddleware } from '@tolgee/core';
-import { xPathEvaluate } from './helpers';
 
 export function NodeHandler(
   options: ObserverOptionsInternal,
@@ -7,15 +6,24 @@ export function NodeHandler(
 ) {
   const self = Object.freeze({
     handleAttributes(node: Node) {
-      let result: Attr[] = [];
+      const result: Attr[] = [];
 
-      const tagAttributes = Object.fromEntries(Object.entries(options.tagAttributes)
-        .map(([tag, attributes]) => [tag.toUpperCase(), attributes])) as Record<string, string[]>;
+      const tagAttributes = Object.fromEntries(
+        Object.entries(options.tagAttributes).map(([tag, attributes]) => [
+          tag.toUpperCase(),
+          attributes,
+        ])
+      ) as Record<string, string[]>;
 
       const tags = new Set(Object.keys(tagAttributes));
-      const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT,
-        f => tags.has((f as Element).tagName.toUpperCase()) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP);
-      
+      const walker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_ELEMENT,
+        (f) =>
+          tags.has((f as Element).tagName.toUpperCase())
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_SKIP
+      );
       while (walker.nextNode()) {
         const element = walker.currentNode as Element;
         const attributes = tagAttributes[element.tagName.toUpperCase()];
@@ -46,8 +54,14 @@ export function NodeHandler(
         return wrapper.testTextNode(node as Text) ? [node as Text] : [];
       }
 
-      const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT,
-        f => wrapper.testTextNode(f as Text) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP);
+      const walker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_TEXT,
+        (f) =>
+          wrapper.testTextNode(f as Text)
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_SKIP
+      );
       const nodes = [];
       while (walker.nextNode()) {
         nodes.push(walker.currentNode);

--- a/packages/web/src/observers/general/NodeHandler.ts
+++ b/packages/web/src/observers/general/NodeHandler.ts
@@ -20,22 +20,25 @@ export function NodeHandler(
         node,
         NodeFilter.SHOW_ELEMENT,
         (f) =>
-          tags.has((f as Element).tagName.toUpperCase())
+          tags.has((f as Element).tagName.toUpperCase()) ||
+          (tags.has('*') &&
+            '*' in tagAttributes &&
+            tagAttributes['*'].some((t) => (f as Element).hasAttribute(t)))
             ? NodeFilter.FILTER_ACCEPT
             : NodeFilter.FILTER_SKIP
       );
       while (walker.nextNode()) {
         const element = walker.currentNode as Element;
-        const attributes = tagAttributes[element.tagName.toUpperCase()];
-        for (const attribute of attributes) {
-          if (!element.hasAttribute(attribute)) {
-            continue;
-          }
-          const attr = element.getAttributeNode(attribute);
-          if (attr && wrapper.testAttribute(attr)) {
-            result.push(attr);
-          }
+        let attributes = tagAttributes[element.tagName.toUpperCase()];
+        if ('*' in tagAttributes) {
+          attributes = attributes.concat(tagAttributes['*']);
         }
+        result.push(
+          ...(attributes
+            .filter((attrName) => element.hasAttribute(attrName))
+            .map((attrName) => element.getAttributeNode(attrName))
+            .filter((attrNode) => wrapper.testAttribute(attrNode)) as Attr[])
+        );
       }
 
       return result;

--- a/packages/web/src/observers/general/NodeHandler.ts
+++ b/packages/web/src/observers/general/NodeHandler.ts
@@ -15,21 +15,19 @@ export function NodeHandler(
         ])
       ) as Record<string, string[]>;
 
-      const tags = new Set(Object.keys(tagAttributes));
       const walker = document.createTreeWalker(
         node,
         NodeFilter.SHOW_ELEMENT,
         (f) =>
-          tags.has((f as Element).tagName.toUpperCase()) ||
-          (tags.has('*') &&
-            '*' in tagAttributes &&
-            tagAttributes['*'].some((t) => (f as Element).hasAttribute(t)))
+          tagAttributes[(f as Element).tagName.toUpperCase()]?.some((t) =>
+            (f as Element).hasAttribute(t)
+          ) || tagAttributes['*']?.some((t) => (f as Element).hasAttribute(t))
             ? NodeFilter.FILTER_ACCEPT
             : NodeFilter.FILTER_SKIP
       );
       while (walker.nextNode()) {
         const element = walker.currentNode as Element;
-        let attributes = tagAttributes[element.tagName.toUpperCase()];
+        let attributes = tagAttributes[element.tagName.toUpperCase()] ?? [];
         if ('*' in tagAttributes) {
           attributes = attributes.concat(tagAttributes['*']);
         }
@@ -37,7 +35,9 @@ export function NodeHandler(
           ...(attributes
             .filter((attrName) => element.hasAttribute(attrName))
             .map((attrName) => element.getAttributeNode(attrName))
-            .filter((attrNode) => wrapper.testAttribute(attrNode)) as Attr[])
+            .filter((attrNode) =>
+              wrapper.testAttribute(attrNode as Attr)
+            ) as Attr[])
         );
       }
 

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -120,13 +120,12 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
 
     testAttribute(attribute: Attr) {
       return (
-        (attribute.value.includes(
+        attribute.value.includes(
           `${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`
         ) ||
-          attribute.value.includes(
-            `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
-          )) ??
-        false
+        attribute.value.includes(
+          `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
+        )
       );
     },
   });

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -102,8 +102,16 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
       return `./descendant-or-self::text()[contains(., '${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}') or contains(., '${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}')]`;
     },
 
+    testTextNode(textNode: Text) {
+      return textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`);
+    },
+
     getAttributeXPath({ tag, attribute }) {
       return `descendant-or-self::${tag}/@${attribute}[contains(., '${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}') or contains(., '${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}')]`;
     },
+
+    testAttribute(attribute: Attr) {
+      return attribute.value.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && attribute.value.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`);
+    }
   });
 }

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -106,7 +106,7 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
       return (
         (textNode.textContent?.includes(
           `${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`
-        ) &&
+        ) ||
           textNode.textContent?.includes(
             `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
           )) ??
@@ -122,7 +122,7 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
       return (
         (attribute.value.includes(
           `${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`
-        ) &&
+        ) ||
           attribute.value.includes(
             `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
           )) ??

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -103,7 +103,7 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
     },
 
     testTextNode(textNode: Text) {
-      return textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`);
+      return (textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`)) ?? false;
     },
 
     getAttributeXPath({ tag, attribute }) {
@@ -111,7 +111,7 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
     },
 
     testAttribute(attribute: Attr) {
-      return attribute.value.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && attribute.value.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`);
+      return (attribute.value.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && attribute.value.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`)) ?? false;
     }
   });
 }

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -103,7 +103,15 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
     },
 
     testTextNode(textNode: Text) {
-      return (textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && textNode.textContent?.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`)) ?? false;
+      return (
+        (textNode.textContent?.includes(
+          `${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`
+        ) &&
+          textNode.textContent?.includes(
+            `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
+          )) ??
+        false
+      );
     },
 
     getAttributeXPath({ tag, attribute }) {
@@ -111,7 +119,15 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
     },
 
     testAttribute(attribute: Attr) {
-      return (attribute.value.includes(`${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`) && attribute.value.includes(`${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`)) ?? false;
-    }
+      return (
+        (attribute.value.includes(
+          `${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}`
+        ) &&
+          attribute.value.includes(
+            `${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}`
+          )) ??
+        false
+      );
+    },
   });
 }

--- a/packages/web/src/observers/invisible/InvisibleWrapper.ts
+++ b/packages/web/src/observers/invisible/InvisibleWrapper.ts
@@ -98,10 +98,6 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
       return typeof value === 'string' ? value + invisibleMark : value;
     },
 
-    getTextXPath() {
-      return `./descendant-or-self::text()[contains(., '${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}') or contains(., '${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}')]`;
-    },
-
     testTextNode(textNode: Text) {
       return (
         (textNode.textContent?.includes(
@@ -112,10 +108,6 @@ export function InvisibleWrapper({ fullKeyEncode }: Props): WrapperMiddleware {
           )) ??
         false
       );
-    },
-
-    getAttributeXPath({ tag, attribute }) {
-      return `descendant-or-self::${tag}/@${attribute}[contains(., '${INVISIBLE_CHARACTERS[0]}${INVISIBLE_CHARACTERS[0]}') or contains(., '${INVISIBLE_CHARACTERS[1]}${INVISIBLE_CHARACTERS[0]}')]`;
     },
 
     testAttribute(attribute: Attr) {

--- a/packages/web/src/observers/text/TextWrapper.ts
+++ b/packages/web/src/observers/text/TextWrapper.ts
@@ -228,7 +228,11 @@ export function TextWrapper({
     },
 
     testTextNode(textNode: Text) {
-      return textNode.textContent?.includes(inputPrefix) && textNode.textContent?.includes(inputSuffix);
+      return (
+        (textNode.textContent?.includes(inputPrefix) &&
+          textNode.textContent?.includes(inputSuffix)) ??
+        false
+      );
     },
 
     getAttributeXPath({ tag, attribute }) {
@@ -236,7 +240,11 @@ export function TextWrapper({
     },
 
     testAttribute(attribute: Attr) {
-      return attribute.value.includes(inputPrefix) && attribute.value.includes(inputSuffix);
+      return (
+        (attribute.value.includes(inputPrefix) &&
+          attribute.value.includes(inputSuffix)) ??
+        false
+      );
     },
   });
 }

--- a/packages/web/src/observers/text/TextWrapper.ts
+++ b/packages/web/src/observers/text/TextWrapper.ts
@@ -241,9 +241,8 @@ export function TextWrapper({
 
     testAttribute(attribute: Attr) {
       return (
-        (attribute.value.includes(inputPrefix) &&
-          attribute.value.includes(inputSuffix)) ??
-        false
+        attribute.value.includes(inputPrefix) &&
+        attribute.value.includes(inputSuffix)
       );
     },
   });

--- a/packages/web/src/observers/text/TextWrapper.ts
+++ b/packages/web/src/observers/text/TextWrapper.ts
@@ -223,20 +223,12 @@ export function TextWrapper({
       return { text: text, keys: [] };
     },
 
-    getTextXPath() {
-      return `./descendant-or-self::text()[contains(., '${inputPrefix}') and contains(., '${inputSuffix}')]`;
-    },
-
     testTextNode(textNode: Text) {
       return (
         (textNode.textContent?.includes(inputPrefix) &&
           textNode.textContent?.includes(inputSuffix)) ??
         false
       );
-    },
-
-    getAttributeXPath({ tag, attribute }) {
-      return `descendant-or-self::${tag}/@${attribute}[contains(., '${inputPrefix}') and contains(., '${inputSuffix}')]`;
     },
 
     testAttribute(attribute: Attr) {

--- a/packages/web/src/observers/text/TextWrapper.ts
+++ b/packages/web/src/observers/text/TextWrapper.ts
@@ -227,8 +227,16 @@ export function TextWrapper({
       return `./descendant-or-self::text()[contains(., '${inputPrefix}') and contains(., '${inputSuffix}')]`;
     },
 
+    testTextNode(textNode: Text) {
+      return textNode.textContent?.includes(inputPrefix) && textNode.textContent?.includes(inputSuffix);
+    },
+
     getAttributeXPath({ tag, attribute }) {
       return `descendant-or-self::${tag}/@${attribute}[contains(., '${inputPrefix}') and contains(., '${inputSuffix}')]`;
+    },
+
+    testAttribute(attribute: Attr) {
+      return attribute.value.includes(inputPrefix) && attribute.value.includes(inputSuffix);
     },
   });
 }


### PR DESCRIPTION
- `meta.nodes` clean up based on `mutation.removedNodes` (opt chance: the `removedNodes` walker may want a better filter`)
- replace XPath-based node handling to Walker-based. This brings 40% better performance based on profiling.