### PR TITLE
inject in-context-tools into head if body is not ready

### DIFF
--- a/packages/web/src/BrowserExtensionPlugin/loadInContextLib.ts
+++ b/packages/web/src/BrowserExtensionPlugin/loadInContextLib.ts
@@ -13,7 +13,11 @@ function injectScript(src: string) {
     script.src = src;
     script.addEventListener('load', () => resolve());
     script.addEventListener('error', (e) => reject(e.error));
-    document.body.appendChild(script);
+    if (document.body) {
+      document.body.appendChild(script);
+    } else {
+      document.head.appendChild(script);
+    }
   });
 }
 

--- a/packages/web/src/BrowserExtensionPlugin/loadInContextLib.ts
+++ b/packages/web/src/BrowserExtensionPlugin/loadInContextLib.ts
@@ -13,11 +13,7 @@ function injectScript(src: string) {
     script.src = src;
     script.addEventListener('load', () => resolve());
     script.addEventListener('error', (e) => reject(e.error));
-    if (document.body) {
-      document.body.appendChild(script);
-    } else {
-      document.head.appendChild(script);
-    }
+    document.head.appendChild(script);
   });
 }
 


### PR DESCRIPTION
For some reason `document.body` is null when loading in-context libs. This will alternatively inject them to `<head>`. 

But I guess we can eliminate the check altogether and inject to `<head>` nevertheless since there will be no difference?