### PR TITLE
fix: update slot translation when language changes

### DIFF
--- a/e2e/cypress/e2e/vue/dev.cy.ts
+++ b/e2e/cypress/e2e/vue/dev.cy.ts
@@ -23,7 +23,7 @@ context('Vue app in dev mode', () => {
         count: 5,
       },
       {
-        text: 'Dies ist ein Schlüssel mit den Parametern value value2',
+        text: 'Dies ist ein Schlüssel mit den Parametern Wert value2',
         count: 3,
       },
     ],

--- a/e2e/cypress/e2e/vue/prod.cy.ts
+++ b/e2e/cypress/e2e/vue/prod.cy.ts
@@ -22,7 +22,7 @@ context('Vue app in prod mode', () => {
         count: 5,
       },
       {
-        text: 'Dies ist ein Schlüssel mit den Parametern value value2',
+        text: 'Dies ist ein Schlüssel mit den Parametern Wert value2',
         count: 3,
       },
     ],

--- a/e2e/import-data/examples/cs.json
+++ b/e2e/import-data/examples/cs.json
@@ -8,5 +8,6 @@
   "share-button" : "Sdílet",
   "this_is_a_key" : "Toto je klíč",
   "this_is_a_key_with_params" : "Toto je klíč s parametry {key} {key2}",
-  "this_is_a_key_with_tags" : "Toto je klíč s tagy <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "Toto je klíč s tagy <b>bold</b> <b><i>{key}</i></b>",
+  "value": "hodnota"
 }

--- a/e2e/import-data/examples/de.json
+++ b/e2e/import-data/examples/de.json
@@ -8,5 +8,6 @@
   "share-button" : "Teilen",
   "this_is_a_key" : "Dies ist ein Schlüssel",
   "this_is_a_key_with_params" : "Dies ist ein Schlüssel mit den Parametern {key} {key2}",
-  "this_is_a_key_with_tags" : "Dies ist ein Schlüssel mit den Tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "Dies ist ein Schlüssel mit den Tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "Wert"
 }

--- a/e2e/import-data/examples/en.json
+++ b/e2e/import-data/examples/en.json
@@ -8,5 +8,6 @@
   "share-button" : "Share",
   "this_is_a_key" : "This is a key",
   "this_is_a_key_with_params" : "This is key with params {key} {key2}",
-  "this_is_a_key_with_tags" : "This is a key with tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "This is a key with tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "value"
 }

--- a/e2e/import-data/examples/fr.json
+++ b/e2e/import-data/examples/fr.json
@@ -8,5 +8,6 @@
   "share-button" : "Partager",
   "this_is_a_key" : "C'est un clé",
   "this_is_a_key_with_params" : "C'est la clé avec paramètres {key} {key2}",
-  "this_is_a_key_with_tags" : "C'est la clé avec des tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "C'est la clé avec des tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "valeur"
 }

--- a/packages/vue/src/T.ts
+++ b/packages/vue/src/T.ts
@@ -4,7 +4,7 @@ import {
   TranslateProps,
   TranslationKey,
 } from '@tolgee/web';
-import { defineComponent, PropType, SetupContext, computed } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { useTranslateInternal } from './useTranslateInternal';
 
 export const T = defineComponent({
@@ -20,22 +20,20 @@ export const T = defineComponent({
     ns: { type: String as PropType<NsType> },
     language: { type: String as PropType<string> },
   },
-  setup(props, context: SetupContext) {
-    const { slots } = context;
+  setup() {
     const { t } = useTranslateInternal();
-    const assignedParams = computed(() => {
-      const slotsParams = {};
-      Object.keys(slots).forEach((key) => {
-        slotsParams[key] = slots[key]();
-      });
-      return Object.assign({}, props.params, slotsParams);
-    });
-    return { t, assignedParams };
+    return { t };
   },
   render() {
+    const slotsParams = {};
+    Object.keys(this.$slots).forEach((key) => {
+      slotsParams[key] = this.$slots[key]();
+    });
+    const assignedParams = Object.assign({}, this.$props.params, slotsParams);
+
     const params: TranslateProps = {
       key: this.$props.keyName,
-      params: this.assignedParams,
+      params: assignedParams,
       defaultValue: this.$props.defaultValue,
       noWrap: this.$props.noWrap,
       ns: this.$props.ns,

--- a/testapps/vue/public/i18n/cs.json
+++ b/testapps/vue/public/i18n/cs.json
@@ -8,5 +8,6 @@
   "share-button" : "Sdílet",
   "this_is_a_key" : "Toto je klíč",
   "this_is_a_key_with_params" : "Toto je klíč s parametry {key} {key2}",
-  "this_is_a_key_with_tags" : "Toto je klíč s tagy <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "Toto je klíč s tagy <b>bold</b> <b><i>{key}</i></b>",
+  "value": "hodnota"
 }

--- a/testapps/vue/public/i18n/de.json
+++ b/testapps/vue/public/i18n/de.json
@@ -8,5 +8,6 @@
   "share-button" : "Teilen",
   "this_is_a_key" : "Dies ist ein Schlüssel",
   "this_is_a_key_with_params" : "Dies ist ein Schlüssel mit den Parametern {key} {key2}",
-  "this_is_a_key_with_tags" : "Dies ist ein Schlüssel mit den Tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "Dies ist ein Schlüssel mit den Tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "Wert"
 }

--- a/testapps/vue/public/i18n/en.json
+++ b/testapps/vue/public/i18n/en.json
@@ -8,5 +8,6 @@
   "share-button" : "Share",
   "this_is_a_key" : "This is a key",
   "this_is_a_key_with_params" : "This is key with params {key} {key2}",
-  "this_is_a_key_with_tags" : "This is a key with tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "This is a key with tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "value"
 }

--- a/testapps/vue/public/i18n/fr.json
+++ b/testapps/vue/public/i18n/fr.json
@@ -8,5 +8,6 @@
   "share-button" : "Partager",
   "this_is_a_key" : "C'est un clé",
   "this_is_a_key_with_params" : "C'est la clé avec paramètres {key} {key2}",
-  "this_is_a_key_with_tags" : "C'est la clé avec des tags <b>bold</b> <b><i>{key}</i></b>"
+  "this_is_a_key_with_tags" : "C'est la clé avec des tags <b>bold</b> <b><i>{key}</i></b>",
+  "value": "valeur"
 }

--- a/testapps/vue/src/TranslationMethods.vue
+++ b/testapps/vue/src/TranslationMethods.vue
@@ -52,7 +52,7 @@
               </span>
             </template>
             <template #key2>
-              <a href="#">{{ $t('value') }}</a>
+              <a href="#">value2</a>
             </template>
           </T>
         </div>

--- a/testapps/vue/src/TranslationMethods.vue
+++ b/testapps/vue/src/TranslationMethods.vue
@@ -26,7 +26,7 @@
         <div>
           <T
             keyName="this_is_a_key_with_params"
-            :params="{ key: 'value', key2: 'value2' }"
+            :params="{ key: $t('value'), key2: 'value2' }"
           />
         </div>
       </div>
@@ -36,7 +36,7 @@
         <div>
           <T
             keyName="this_is_a_key_with_params"
-            :params="{ key: 'value', key2: 'value2' }"
+            :params="{ key: $t('value'), key2: 'value2' }"
             noWrap
           />
         </div>
@@ -47,10 +47,12 @@
         <div>
           <T keyName="this_is_a_key_with_params">
             <template #key>
-              <span class="custom_class">value</span>
+              <span class="custom_class">
+                {{ $t('value') }}
+              </span>
             </template>
             <template #key2>
-              <a href="#">value2</a>
+              <a href="#">{{ $t('value') }}</a>
             </template>
           </T>
         </div>
@@ -65,7 +67,10 @@
         <h1>t function with params</h1>
         <div>
           {{
-            $t('this_is_a_key_with_params', { key: 'value', key2: 'value2' })
+            $t('this_is_a_key_with_params', {
+              key: $t('value'),
+              key2: 'value2',
+            })
           }}
         </div>
       </div>
@@ -88,7 +93,7 @@
           {{
             $t({
               key: 'this_is_a_key',
-              params: { key: 'value', key2: 'value2' },
+              params: { key: $t('value'), key2: 'value2' },
             })
           }}
         </div>
@@ -100,7 +105,7 @@
           {{
             $t({
               key: 'this_is_a_key',
-              params: { key: 'value', key2: 'value2' },
+              params: { key: $t('value'), key2: 'value2' },
               noWrap: true,
             })
           }}


### PR DESCRIPTION
Translations in slots are not updated when the language changes.

**Expected Result**
When the language changes, all translations, including those in slots, should update dynamically.

**Current Result**
Translations in slots remain unchanged when the language is changed, requiring a manual refresh to update.

**Reproduction**
You can see the issue in this [CodeSandbox](https://codesandbox.io/p/sandbox/crazy-browser-nlnpsd?file=%2Fpublic%2Fi18n%2Fde.json%3A4%2C2).