### PR TITLE
fix: handle tolgee instance update (on hot reload)

### DIFF
--- a/packages/react/src/TolgeeProvider.tsx
+++ b/packages/react/src/TolgeeProvider.tsx
@@ -18,6 +18,8 @@ export const getProviderInstance = () => {
   return ProviderInstance;
 };
 
+let LAST_TOLGEE_INSTANCE: TolgeeInstance | undefined = undefined;
+
 export interface TolgeeProviderProps {
   children?: React.ReactNode;
   tolgee: TolgeeInstance;
@@ -33,17 +35,25 @@ export const TolgeeProvider: React.FC<TolgeeProviderProps> = ({
 }) => {
   const [loading, setLoading] = useState(!tolgee.isLoaded());
 
+  // prevent restarting tolgee unnecesarly
+  // however if the instance change on hot-reloading
+  // we want to restart
   useEffect(() => {
-    tolgee
-      .run()
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-    return () => tolgee.stop();
+    if (LAST_TOLGEE_INSTANCE !== tolgee) {
+      if (LAST_TOLGEE_INSTANCE) {
+        LAST_TOLGEE_INSTANCE.stop();
+      }
+      LAST_TOLGEE_INSTANCE = tolgee;
+      tolgee
+        .run()
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error(e);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
   }, [tolgee]);
 
   const optionsWithDefault = { ...DEFAULT_REACT_OPTIONS, ...options };

--- a/packages/react/src/TolgeeProvider.tsx
+++ b/packages/react/src/TolgeeProvider.tsx
@@ -43,6 +43,7 @@ export const TolgeeProvider: React.FC<TolgeeProviderProps> = ({
       .finally(() => {
         setLoading(false);
       });
+    return () => tolgee.stop();
   }, [tolgee]);
 
   const optionsWithDefault = { ...DEFAULT_REACT_OPTIONS, ...options };

--- a/testapps/react/README.md
+++ b/testapps/react/README.md
@@ -17,7 +17,7 @@ To run the app in dev mode with in-context translating mode:
 2. Generate an API-KEY
 3. Copy file `.env` to `.env.development.local`
 4. Set `VITE_APP_TOLGEE_API_KEY` to API key obtained in previous step
-5. Run `npm run start`
+5. Run `npm run develop`
 6. Have fun
 
 ## To run the app in production mode


### PR DESCRIPTION
Stop tolgee instance when there is a new one. It can happen when there is a hot-reloading with branch name switching, as it creates new tolgee instance without reloading the page and then there are two instances running at the same time