### PR TITLE
Fix $t function to correctly render keys from loaded namespaces

### DIFF
--- a/packages/vue/src/VueTolgee.ts
+++ b/packages/vue/src/VueTolgee.ts
@@ -61,6 +61,12 @@ export const VueTolgee = {
       );
     }
 
+    reactiveContext.value.tolgee.on('cache', () => {
+      reactiveContext.value.tolgee = Object.freeze({
+        ...reactiveContext.value.tolgee,
+      });
+    });
+
     app.config.globalProperties.$t = ((...args: Parameters<TolgeeT>) =>
       reactiveContext.value.tolgee.t(...args)) as TolgeeT;
 


### PR DESCRIPTION
Resolves an issue where the $t function was not properly rendering translation keys from loaded namespaces.