### PR TITLE
fix: make Tolgee work in old browsers

### DIFF
--- a/packages/web/src/package/observers/invisible/secret.ts
+++ b/packages/web/src/package/observers/invisible/secret.ts
@@ -8,7 +8,7 @@ export const INVISIBLE_CHARACTERS = ['\u200C', '\u200D'];
 
 export const INVISIBLE_REGEX = RegExp(
   `([${INVISIBLE_CHARACTERS.join('')}]{9})+`,
-  'gu'
+  typeof /x/.unicode !== 'undefined' ? 'gu' : 'g'
 );
 
 function toBytes(text: string) {

--- a/packages/web/src/package/observers/text/TextWrapper.ts
+++ b/packages/web/src/package/observers/text/TextWrapper.ts
@@ -139,7 +139,7 @@ export function TextWrapper({
 
   function escapeParam(param: any) {
     if (typeof param === 'string') {
-      return param.replace(/[,:|\\]/gs, '\\$&');
+      return param.replace(/[,:|\\]/g, '\\$&');
     }
     if (typeof param === 'number' || typeof param === 'bigint') {
       return param.toString();
@@ -176,7 +176,10 @@ export function TextWrapper({
     },
 
     unwrap(text: string) {
-      const matchRegexp = new RegExp(getRawUnWrapRegex(), 'gs');
+      const matchRegexp = new RegExp(
+        getRawUnWrapRegex(),
+        typeof /x/.dotAll !== 'undefined' ? 'gs' : 'g'
+      );
 
       const keysAndParams: KeyAndParams[] = [];
 

--- a/packages/web/src/package/observers/text/TextWrapper.ts
+++ b/packages/web/src/package/observers/text/TextWrapper.ts
@@ -176,10 +176,7 @@ export function TextWrapper({
     },
 
     unwrap(text: string) {
-      const matchRegexp = new RegExp(
-        getRawUnWrapRegex(),
-        typeof /x/.dotAll !== 'undefined' ? 'gs' : 'g'
-      );
+      const matchRegexp = new RegExp(getRawUnWrapRegex(), 'gs');
 
       const keysAndParams: KeyAndParams[] = [];
 


### PR DESCRIPTION
This PR fixes #3465.

[`u`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) and [`s`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) keys used in regular expressions are not supported by some browsers.

`s` key is irrelevant in `/[,:|\\]/`, because this regular expression does not include `.` character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of regular expressions with different environments by conditionally applying Unicode and dotAll flags.
  * Resolved issues related to unsupported regex flags, ensuring more reliable text processing across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->