### PR TITLE
Fix false-positive "Missing records in staticData" warning in useTolgeeSSR

### DIFF
--- a/packages/react/src/useTolgeeSSR.ts
+++ b/packages/react/src/useTolgeeSSR.ts
@@ -68,7 +68,7 @@ export function useTolgeeSSR(
       const providedRecords = tolgeeInstance.getAllRecords();
       const missingRecords = requiredRecords
         .map(({ namespace, language }) =>
-          namespace ? `${namespace}:${language}` : language
+          namespace ? `${language}:${namespace}` : language
         )
         .filter((key) => !providedRecords.find((r) => r?.cacheKey === key));
 

--- a/packages/vue/src/TolgeeProvider.ts
+++ b/packages/vue/src/TolgeeProvider.ts
@@ -68,7 +68,7 @@ export const TolgeeProvider = defineComponent({
         const missingRecords = tolgee.value
           .getRequiredDescriptors(ssr.language)
           .map(({ namespace, language }) =>
-            namespace ? `${namespace}:${language}` : language
+            namespace ? `${language}:${namespace}` : language
           )
           .filter((key) => !ssr.staticData?.[key]);
 


### PR DESCRIPTION
## Summary

`useTolgeeSSR` logs `Tolgee: Missing records in "staticData" for proper SSR functionality: "<ns>:<lang>"` even when the required records are present in `staticData`. SSR itself works correctly — only the warning is wrong.

## Root cause

The check compares two differently-ordered keys:

- **Required** records are stringified inline as `` `${namespace}:${language}` `` (e.g. `"web:en"`).
- **Provided** records come from `tolgee.getAllRecords()`, whose `cacheKey` is produced by `encodeCacheKey` in `@tolgee/core` as `` `${language}:${namespace}` `` (e.g. `"en:web"`).

Because the two are inverted, the `.filter(...)` never finds a match and every required record is reported as missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side rendering to correctly identify missing records when namespace configuration is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->