### PR TITLE
fix(web): render in-context editor in browser top layer

### DIFF
--- a/packages/web/src/package/ui/KeyDialog/TranslationDialogWrapper.tsx
+++ b/packages/web/src/package/ui/KeyDialog/TranslationDialogWrapper.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { Dialog } from '@mui/material';
+import React, { useEffect, useRef } from 'react';
+import { Dialog, GlobalStyles } from '@mui/material';
 
 import { useDialogContext, useDialogActions } from './dialogContext';
 import { NewWindow } from './NewWindow';
 import { DEVTOOLS_Z_INDEX } from '../../constants';
+
+const TOP_LAYER_CLASS = 'tolgee-key-dialog-top-layer';
 
 export const TranslationDialogWrapper = ({
   children,
@@ -11,12 +13,62 @@ export const TranslationDialogWrapper = ({
   const { onClose } = useDialogActions();
   const useBrowserWindow = useDialogContext((c) => c.useBrowserWindow);
   const takingScreenshot = useDialogContext((c) => c.takingScreenshot);
+  const nativeDialogRef = useRef<HTMLDialogElement>(null);
+
+  // Promote the editor into the browser top layer so it paints above and
+  // takes focus from any modal <dialog> the host app may have open.
+  useEffect(() => {
+    if (useBrowserWindow) return;
+    const dialog = nativeDialogRef.current;
+    if (!dialog) return;
+    if (!dialog.open) {
+      dialog.showModal();
+    }
+    const handleCancel = (e: Event) => {
+      // Defer to the existing Escape handler in dialogContext so close flow
+      // stays in one place; prevent the browser from closing the dialog itself.
+      e.preventDefault();
+    };
+    dialog.addEventListener('cancel', handleCancel);
+    return () => {
+      dialog.removeEventListener('cancel', handleCancel);
+      if (dialog.open) dialog.close();
+    };
+  }, [useBrowserWindow]);
+
+  if (useBrowserWindow) {
+    return <NewWindow>{children}</NewWindow>;
+  }
 
   return (
     <>
-      {useBrowserWindow ? (
-        <NewWindow>{children}</NewWindow>
-      ) : (
+      <GlobalStyles
+        styles={{
+          [`dialog.${TOP_LAYER_CLASS}`]: {
+            padding: 0,
+            border: 0,
+            margin: 0,
+            inset: 0,
+            width: '100vw',
+            height: '100vh',
+            maxWidth: 'none',
+            maxHeight: 'none',
+            background: 'transparent',
+            color: 'inherit',
+            overflow: 'visible',
+            // Let pointer events fall through to MUI's backdrop/paper, which
+            // already handle outside-click-to-close.
+            pointerEvents: 'none',
+          },
+          [`dialog.${TOP_LAYER_CLASS}::backdrop`]: {
+            background: 'transparent',
+          },
+          [`dialog.${TOP_LAYER_CLASS} > *`]: {
+            pointerEvents: 'auto',
+          },
+        }}
+      />
+      <dialog ref={nativeDialogRef} className={TOP_LAYER_CLASS}>
         <Dialog
           disableRestoreFocus
           disableEnforceFocus
@@ -32,7 +84,7 @@ export const TranslationDialogWrapper = ({
         >
           <>{children}</>
         </Dialog>
-      )}
+      </dialog>
     </>
   );
 };

--- a/testapps/react/src/TranslationMethods.tsx
+++ b/testapps/react/src/TranslationMethods.tsx
@@ -1,4 +1,4 @@
-import { useState, Suspense } from 'react';
+import { useRef, useState, Suspense } from 'react';
 import { T, useTranslate } from '@tolgee/react';
 
 import { Navbar } from './components/Navbar';
@@ -7,6 +7,7 @@ import { Namespaces } from './components/Namespaces';
 export const TranslationMethods = () => {
   const { t } = useTranslate();
   const [revealed, setRevealed] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   return (
     <main className="translation-methods">
@@ -137,6 +138,30 @@ export const TranslationMethods = () => {
                 {'<b>Translation</b> in translation'}
               </T>
             </div>
+          </div>
+        </div>
+
+        <div>
+          <h1>Translation inside dialog</h1>
+          <div>
+            <button
+              className="button"
+              data-cy="openDialogButton"
+              onClick={() => dialogRef.current?.showModal()}
+            >
+              Open dialog
+            </button>
+            <dialog ref={dialogRef} data-cy="translationDialog">
+              <div data-cy="translationDialogContent">
+                <T
+                  keyName="this_is_a_key_in_dialog"
+                  defaultValue="This is a translation inside a dialog"
+                />
+              </div>
+              <form method="dialog">
+                <button className="button">Close</button>
+              </form>
+            </dialog>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problem

When a translation key sits inside a native `<dialog>` opened with `showModal()`, alt-clicking it opens the Tolgee Quick translation editor — but the host dialog paints **on top of** the editor and steals focus from its inputs. The editor becomes unusable: you can see the form behind the host dialog, but you can't type into it.

Repro on this branch: `testapps/react` → `/translation-methods` → "Open dialog" → alt-click the translation inside.

## Cause

A modal `<dialog>` element (one opened via `.showModal()`) is promoted to the browser's **top layer**, a special render layer that sits above the entire normal stacking context. `z-index` cannot reach the top layer, and the dialog enforces a focus scope.

The in-context editor was rendered via MUI's `<Dialog>` (`packages/web/src/package/ui/KeyDialog/TranslationDialogWrapper.tsx`) — a portal'd `<div>` with `zIndex: DEVTOOLS_Z_INDEX`. No matter how large that z-index is, a host modal `<dialog>` paints above it.

## Solution

Wrap the existing MUI `<Dialog>` in a native `<dialog>` element and call `showModal()` on mount. That promotes the editor into the same top layer as any host modal. The top layer behaves like a stack — the most-recently-shown modal paints above earlier ones and receives focus — so the editor now overlays the host dialog and takes focus from it.

Implementation notes:

- Native `<dialog>` UA defaults (border, padding, centred sizing) are flattened via `GlobalStyles`. The native `::backdrop` is set transparent because MUI's own backdrop continues to provide the dim overlay.
- `pointer-events: none` on the native `<dialog>` with `pointer-events: auto` on its children lets MUI's backdrop keep handling outside-click-to-close.
- The native `cancel` event (Escape) is `preventDefault`-ed so the existing Escape handler in `dialogContext` remains the single source of truth for closing.
- The `useBrowserWindow` path (open editor in a detached window) is untouched.
- The editor lives inside a shadow root, which doesn't affect this — the top layer is per-document, so a `<dialog>` inside shadow DOM is still promoted to the document's top layer.

## Test plan

- [ ] **Repro fixed:** in `testapps/react` at `/translation-methods`, open the new "Translation inside dialog" example and alt-click the key inside — Quick translation editor paints above the host `<dialog>` and the English input receives focus.
- [ ] **Existing alt-click behaviour preserved** on translations outside any dialog.
- [ ] **Escape closes the editor** (and only the editor — the host dialog stays open).
- [ ] **Click outside the editor paper** (on MUI's backdrop) closes the editor.
- [ ] **Screenshot mode:** click the camera icon — editor disappears for the capture and reappears after.
- [ ] **Open in browser window** (the `useBrowserWindow` path) still works.
- [ ] **Focus return on close:** closing the editor returns focus into the host `<dialog>` so its own focus trap resumes.
- [ ] Cross-browser smoke: Chrome, Firefox, Safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native modal dialog support for translation interfaces.
  * Dialog overlays now cover the full viewport with transparent styling and controlled interactions.
  * Added support for displaying translated content directly within native dialogs, including close controls.
  * Tooltips now appear inside open dialogs to keep related guidance visible in context.
  * Dialogs opened in separate browser windows continue to be supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->