### PR TITLE
fix(react): allow T component under React 19

### DIFF
--- a/packages/react/src/T.tsx
+++ b/packages/react/src/T.tsx
@@ -5,11 +5,7 @@ import { useTranslateInternal } from './useTranslateInternal';
 import { TFnType } from '@tolgee/web';
 import { TBase } from './TBase';
 
-interface TInterface {
-  (props: TProps): JSX.Element;
-}
-
-export const T: TInterface = (props) => {
+export const T = (props: TProps): React.ReactElement => {
   const { t } = useTranslateInternal();
 
   return <TBase t={t as TFnType<ParamsTags>} {...props} />;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -10,7 +10,7 @@ import type {
 
 export type ParamsTags =
   | DefaultParamType
-  | ((value: any) => JSX.Element | React.ReactElement | null)
+  | ((value: any) => React.ReactElement | null)
   | React.ReactNode;
 
 export type ReactOptions = {
@@ -41,6 +41,6 @@ export interface PropsWithoutKeyName extends PropsBase {
 
 export type TProps = PropsWithKeyName | PropsWithoutKeyName;
 
-export interface TBaseInterface {
-  (props: TProps & { t: TFnType<ParamsTags> }): JSX.Element;
-}
+export type TBaseInterface = (
+  props: TProps & { t: TFnType<ParamsTags> }
+) => React.ReactElement;


### PR DESCRIPTION
## Problem

`<T>` from `@tolgee/react` cannot be used as a JSX component under
React 19. TypeScript reports:

> TS2786: 'T' cannot be used as a JSX component. Its type 'TInterface'
> is not a valid JSX element type.

The only workaround consumers found was casting the import themselves:

```ts
import { T as TolgeeT, TProps } from '@tolgee/react';
const T = TolgeeT as React.FC<TProps>;
```

## Root cause

`packages/react/src/T.tsx` declares the component via a call-signature
interface returning bare `JSX.Element`:

```ts
interface TInterface {
  (props: TProps): JSX.Element;
}
export const T: TInterface = (props) => { ... };
```

Two things bite simultaneously under React 19:

1. `@types/react@19` no longer declares the global `JSX` namespace —
   it now lives at `React.JSX`. Bare `JSX.Element` in the emitted
   `.d.ts` no longer resolves the way consumers expect.
2. React 19 tightened `JSX.ElementType`. A call-signature interface
   returning `JSX.Element` is no longer accepted as a valid component
   type — hence TS2786.

PR #3407 widened the peer-dep range to allow React 19 to install, but
did not touch source types.

## Solution

Replace the call-signature interfaces with plain function declarations
returning `React.ReactElement` in `T.tsx` and `types.ts`. Apply the
same treatment to `TBaseInterface` and the `ParamsTags` union (the
latter referenced `JSX.Element | React.ReactElement | null`, which
collapse to the same thing).

Internal-only signature change. No runtime impact.

## Verification

- `cd packages/react && npx jest --no-coverage` — 34 passed.
- `cd packages/react && npx tsc -p tsconfig.prod.json --noEmit` — clean.

## Test plan

- [ ] React 19 sandbox project (`@types/react@19`) imports `T` and
      uses `<T keyName="x">y</T>` — TS2786 should not fire.
- [ ] Existing React 17/18 consumers continue to type-check.