### PR TITLE
chore(testapps/react): demonstrate typed namespace constants

### DIFF
--- a/testapps/react/src/components/Namespaces.tsx
+++ b/testapps/react/src/components/Namespaces.tsx
@@ -1,7 +1,12 @@
 import { useTranslate, T } from '@tolgee/react';
 
+// Declared inline so the tolgee-cli extractor can resolve `NS.NAMESPACED` —
+// cross-file resolution is not yet supported. See ../i18n/namespaces.ts for
+// the shared definition (mirror this entry there when adding new namespaces).
+const NS = { NAMESPACED: 'namespaced' } as const;
+
 export const Namespaces = () => {
-  const { t } = useTranslate('namespaced');
+  const { t } = useTranslate(NS.NAMESPACED);
 
   return (
     <div className="tiles namespaces">
@@ -18,7 +23,7 @@ export const Namespaces = () => {
       <div>
         <h1>T component with namespace</h1>
         <div>
-          <T keyName="this_is_a_key" ns="namespaced" />
+          <T keyName="this_is_a_key" ns={NS.NAMESPACED} />
         </div>
       </div>
     </div>

--- a/testapps/react/src/i18n/namespaces.ts
+++ b/testapps/react/src/i18n/namespaces.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for namespace identifiers used in this app.
+ *
+ * The Tolgee CLI extractor resolves `const NS = { ... } as const` references
+ * within a single file, but it does NOT yet follow imports. Until cross-file
+ * resolution lands, consumers (e.g. components/Namespaces.tsx) must also
+ * declare an inline `const NS` mirroring the entries used in that file.
+ * Keep this file as the authoritative list and mirror entries on demand.
+ */
+export const NS = {
+  NAMESPACED: 'namespaced',
+} as const;
+
+export type Namespace = (typeof NS)[keyof typeof NS];


### PR DESCRIPTION
## Problem

The React testapp uses bare string literals for translation namespaces:

```tsx
const { t } = useTranslate('namespaced');
<T keyName="this_is_a_key" ns="namespaced" />
```

That's fine in isolation but it doesn't model what most production
codebases want: a single typed source of truth for namespace
identifiers. The companion tolgee-cli PR
(https://github.com/tolgee/tolgee-cli/pull/202) makes the extractor
able to resolve `const NS = { ... } as const` references — this PR
demonstrates the recommended shape in the testapp.

## Solution

- New `testapps/react/src/i18n/namespaces.ts` exporting
  `NS = { NAMESPACED: 'namespaced' } as const` — the authoritative
  shared list, intended for runtime use across components.
- Updated `Namespaces.tsx` to declare a mirroring inline
  `const NS = { NAMESPACED: 'namespaced' } as const` and use
  `NS.NAMESPACED` for both `useTranslate(...)` and `<T ns={...}>`.

The inline declaration is a deliberate workaround: the extractor's
const resolution is same-file only today, so importing from
`i18n/namespaces.ts` would still trigger `W_DYNAMIC_NAMESPACE`. A
follow-up extending tolgee-cli to follow imports would let consumers
drop the inline mirror.

## Verification

- `cd testapps/react && npx tsc --noEmit` — clean.
- Running the tolgee-cli extractor (with the companion PR applied)
  against `Namespaces.tsx` extracts 3 keys with namespace
  `namespaced` and emits zero warnings.

## Test plan

- [ ] `cd testapps/react && npm run develop` renders the Namespaces
      panel correctly.
- [ ] Once the companion tolgee-cli PR is merged and a release cut,
      drop the inline mirror and import `NS` from
      `../i18n/namespaces` instead.

## Companion PR

- tolgee-cli: https://github.com/tolgee/tolgee-cli/pull/202