### PR TITLE
feat: render msgctxt chip in key dialog

### DIFF
--- a/packages/web/src/package/ui/KeyDialog/KeyForm.tsx
+++ b/packages/web/src/package/ui/KeyDialog/KeyForm.tsx
@@ -29,6 +29,7 @@ import { ErrorAlert } from './ErrorAlert';
 import { HttpError } from '../client/HttpError';
 import { Tooltip } from '../common/Tooltip';
 import { FilterTagMissingInfo } from './Tags/FilterTagMissingInfo';
+import { KeyName } from '../common/KeyName';
 
 const ScContainer = styled('div')`
   font-family: Rubik, Roboto, Arial;
@@ -210,7 +211,7 @@ export const KeyForm = () => {
         )}
       </ScTitle>
       <ScValue>
-        {input}
+        <KeyName name={input} />
         <ScHint>{!keyExists && ready && " (key doesn't exist yet)"}</ScHint>
       </ScValue>
       <NsSelect

--- a/packages/web/src/package/ui/KeyDialog/ScreenshotGallery/ScreenshotWithLabels.tsx
+++ b/packages/web/src/package/ui/KeyDialog/ScreenshotGallery/ScreenshotWithLabels.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { KeyName } from '../../common/KeyName';
 
 import { components } from '../../client/apiSchema.generated';
 import { Tooltip } from '../../common/Tooltip';
@@ -78,7 +79,11 @@ export const ScreenshotWithLabels: React.FC<Props> = ({
           );
           if (showTooltips) {
             return (
-              <Tooltip key={i} title={key.keyName} placement="right">
+              <Tooltip
+                key={i}
+                title={<KeyName name={key.keyName} />}
+                placement="right"
+              >
                 {rectangle}
               </Tooltip>
             );

--- a/packages/web/src/package/ui/common/KeyName.tsx
+++ b/packages/web/src/package/ui/common/KeyName.tsx
@@ -1,0 +1,42 @@
+import { styled } from '@mui/material';
+
+const PO_MSGCTXT_KEY_SEPARATOR = '\u0004';
+
+const ScWrapper = styled('span')`
+  display: inline;
+`;
+
+const ScMsgctxt = styled('span')`
+  display: inline-flex;
+  vertical-align: text-top;
+  align-items: center;
+  justify-content: center;
+  min-width: 15px;
+  border: 1px solid #bbc2cb;
+  background-color: #f0f2f4;
+  color: #4d5b6e;
+  border-radius: 10px;
+  padding: 0px 7px;
+  font-size: 12px;
+  user-select: none;
+  margin: 0px 4px 0px 1px;
+  overflow: hidden;
+  font-family: monospace;
+`;
+
+type Props = {
+  name: string;
+};
+
+export const KeyName: React.FC<Props> = ({ name }) => {
+  const idx = name.indexOf(PO_MSGCTXT_KEY_SEPARATOR);
+  if (idx <= 0) {
+    return <ScWrapper>{name.replace(PO_MSGCTXT_KEY_SEPARATOR, '')}</ScWrapper>;
+  }
+  return (
+    <ScWrapper>
+      <ScMsgctxt>{name.slice(0, idx)}</ScMsgctxt>
+      {name.slice(idx + 1)}
+    </ScWrapper>
+  );
+};


### PR DESCRIPTION
## Summary
- The in-context **KeyDialog** and the **ScreenshotWithLabels** tooltip now use a new `<KeyName>` component that splits the key name on the U+0004 separator (set by tolgee-platform when importing gettext `.po` files with a `msgctxt`) and renders the `msgctxt` portion as a styled chip in front of the `msgid`.
- Standalone implementation — no runtime dependency on `@tginternal/editor` to keep this package's bundle independent of release coordination.
- The platform-side change introducing the separator and the matching chip visual lives in the companion tolgee-platform PR.

## Companion PRs
- tolgee-platform: https://github.com/tolgee/tolgee-platform/pull/3694
- editor: https://github.com/tolgee/editor/pull/8
- documentation: https://github.com/tolgee/documentation/pull/1111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved key name rendering with enhanced formatting that visually distinguishes embedded metadata using dedicated styling
  * Updated the UI across dialogs and tooltips to consistently leverage the new key name display, improving visual clarity and presentation when viewing keys with associated metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-js/pull/3523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->