### PR TITLE
fix: stop false-positive "Missing records in staticData" SSR warning

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { getFallback, getFallbackArray, createFetchFunction } from './helpers';
+export { encodeCacheKey } from './Controller/Cache/helpers';
 export { TolgeeCore } from './TolgeeCore';
 export * from './types';
 export { getTranslateProps } from './TranslateParams';

--- a/packages/react/src/__integration/useTolgeeSSR.spec.tsx
+++ b/packages/react/src/__integration/useTolgeeSSR.spec.tsx
@@ -1,0 +1,51 @@
+import React, { act } from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { Tolgee, TolgeeInstance, encodeCacheKey } from '@tolgee/web';
+import { useTolgeeSSR } from '..';
+
+const enCommon = { hello: 'Hello' };
+
+describe('useTolgeeSSR missing-records warning', () => {
+  let tolgee: TolgeeInstance;
+  let warnSpy: jest.SpyInstance;
+
+  const SsrComponent = ({
+    data,
+  }: {
+    data: Record<string, Record<string, string>>;
+  }) => {
+    useTolgeeSSR(tolgee, 'en', data);
+    return null;
+  };
+
+  beforeEach(() => {
+    // not run() -> a required record stays uncached so isLoaded() is false and
+    // the SSR warning path runs
+    tolgee = Tolgee().init({ language: 'en', ns: ['common', 'extra'] });
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    tolgee.stop();
+  });
+
+  it('warns only about genuinely missing records, using the canonical language:namespace key', () => {
+    act(() => {
+      render(
+        <SsrComponent
+          data={{
+            [encodeCacheKey({ language: 'en', namespace: 'common' })]: enCommon,
+          }}
+        />
+      );
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Tolgee: Missing records in "staticData" for proper SSR functionality: "${encodeCacheKey(
+        { language: 'en', namespace: 'extra' }
+      )}"`
+    );
+  });
+});

--- a/packages/react/src/useTolgeeSSR.ts
+++ b/packages/react/src/useTolgeeSSR.ts
@@ -1,5 +1,6 @@
 import {
   CachePublicRecord,
+  encodeCacheKey,
   getTranslateProps,
   TolgeeInstance,
   TolgeeStaticData,
@@ -67,15 +68,15 @@ export function useTolgeeSSR(
       const requiredRecords = tolgeeInstance.getRequiredDescriptors(language);
       const providedRecords = tolgeeInstance.getAllRecords();
       const missingRecords = requiredRecords
-        .map(({ namespace, language }) =>
-          namespace ? `${namespace}:${language}` : language
-        )
+        .map((descriptor) => encodeCacheKey(descriptor))
         .filter((key) => !providedRecords.find((r) => r?.cacheKey === key));
 
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Tolgee: Missing records in "staticData" for proper SSR functionality: ${missingRecords.map((key) => `"${key}"`).join(', ')}`
-      );
+      if (missingRecords.length) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Tolgee: Missing records in "staticData" for proper SSR functionality: ${missingRecords.map((key) => `"${key}"`).join(', ')}`
+        );
+      }
     }
   });
 

--- a/packages/vue/src/TolgeeProvider.ts
+++ b/packages/vue/src/TolgeeProvider.ts
@@ -10,7 +10,11 @@ import {
   computed,
 } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
-import { TolgeeInstance, TolgeeStaticDataProp } from '@tolgee/web';
+import {
+  TolgeeInstance,
+  TolgeeStaticDataProp,
+  encodeCacheKey,
+} from '@tolgee/web';
 import { TolgeeVueContext } from './types';
 
 export type SSROptions = {
@@ -67,15 +71,15 @@ export const TolgeeProvider = defineComponent({
         // for proper SSR render
         const missingRecords = tolgee.value
           .getRequiredDescriptors(ssr.language)
-          .map(({ namespace, language }) =>
-            namespace ? `${namespace}:${language}` : language
-          )
+          .map((descriptor) => encodeCacheKey(descriptor))
           .filter((key) => !ssr.staticData?.[key]);
 
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Tolgee: Missing records in "staticData" for proper SSR functionality: ${missingRecords.map((key) => `"${key}"`).join(', ')}`
-        );
+        if (missingRecords.length) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Tolgee: Missing records in "staticData" for proper SSR functionality: ${missingRecords.map((key) => `"${key}"`).join(', ')}`
+          );
+        }
       }
     }
 

--- a/packages/vue/src/__integration/TolgeeProviderSsr.spec.ts
+++ b/packages/vue/src/__integration/TolgeeProviderSsr.spec.ts
@@ -1,0 +1,74 @@
+jest.autoMockOff();
+
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/vue';
+
+import {
+  TolgeeProvider,
+  VueTolgee,
+  Tolgee,
+  TolgeeInstance,
+  encodeCacheKey,
+} from '..';
+
+const enCommon = { hello: 'Hello' };
+const enExtra = { bye: 'Bye' };
+const commonKey = encodeCacheKey({ language: 'en', namespace: 'common' });
+const extraKey = encodeCacheKey({ language: 'en', namespace: 'extra' });
+
+const SsrWrapper = {
+  components: { TolgeeProvider },
+  template: `<TolgeeProvider :ssr="ssr"><div /></TolgeeProvider>`,
+  props: ['ssr'],
+};
+
+function renderWithSsr(tolgee: TolgeeInstance, ssr: Record<string, unknown>) {
+  return render(SsrWrapper, {
+    props: { ssr },
+    global: { plugins: [[VueTolgee, { tolgee, enableSSR: true }]] },
+  });
+}
+
+describe('TolgeeProvider SSR missing-records warning', () => {
+  let tolgee: TolgeeInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // not run() -> isLoaded() stays false so the SSR warning path is exercised
+    tolgee = Tolgee().init({ language: 'en', ns: ['common', 'extra'] });
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    tolgee.stop();
+  });
+
+  it('warns only about genuinely missing records, using the canonical language:namespace key', () => {
+    renderWithSsr(tolgee, {
+      language: 'en',
+      staticData: { [commonKey]: enCommon },
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Tolgee: Missing records in "staticData" for proper SSR functionality: "${extraKey}"`
+    );
+  });
+
+  it('does not emit an empty warning when lazy static data covers every required record', () => {
+    // Function-valued static data is not written to the cache, so isLoaded()
+    // stays false and the warning path runs — but every required key is present,
+    // so missingRecords is empty and nothing should be logged.
+    renderWithSsr(tolgee, {
+      language: 'en',
+      staticData: {
+        [commonKey]: () => Promise.resolve(enCommon),
+        [extraKey]: () => Promise.resolve(enExtra),
+      },
+    });
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Missing records')
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`useTolgeeSSR` (React) and `TolgeeProvider` (Vue) log

> `Tolgee: Missing records in "staticData" for proper SSR functionality: "<ns>:<lang>"`

even when the required records **are** present in `staticData`. SSR works correctly — the warning is simply wrong, which sends users debugging a non-existent problem.

The two sites built the comparison key inline as `` `${namespace}:${language}` ``, but every cache key in `@tolgee/core` is produced by `encodeCacheKey` as `` `${language}:${namespace}` ``. Because the orders are inverted, the lookup never matched and every record was reported missing.

This duplicated, hand-rolled encoding is the root cause: the format rule lived in three independent copies, and the two SSR copies silently drifted from the canonical one.

## Solution

- Export `encodeCacheKey` from `@tolgee/core` (it already flows to `@tolgee/web` via `export *`) and reuse it at both SSR sites instead of re-deriving the key format. This removes the duplication so the orders can no longer drift apart.
- Emit the warning only when records are actually missing — a sufficient `staticData` set previously still logged an empty `…functionality: ` message (reachable in Vue via lazy/function-valued static data).
- Add regression tests: both packages cover the false-positive (a provided namespaced record must not be reported missing), and Vue additionally covers the empty-list guard via function-valued static data. The expected key is derived from `encodeCacheKey` so the tests catch any future drift on either side.

## Out of scope

In React the missing-records check compares against the cache (`getAllRecords()`), which never stores function-valued (lazy) static data, so a React app that supplies *all* required namespaces as lazy loaders would still see a false warning. This is pre-existing behaviour on a different axis (lazy vs. eager) and is left for a separate change; the React empty-records guard here is therefore defensive only, since missing-records and the loaded check derive from the same cache.

Supersedes #3518 (external PR; reuses the canonical encoder rather than only correcting the literals, and adds tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed encodeCacheKey in the core package API.

* **Bug Fixes**
  * Improved SSR missing-records detection consistency by standardizing cache key encoding across React and Vue.

* **Tests**
  * Added integration tests covering SSR missing-records warning behavior in React and Vue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->