### PR TITLE
docs: fix contributors link in READMEs (#3432)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Read more on the [Tolgee website](https://tolgee.io)
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -163,7 +163,7 @@ pnpm run e2e open <integration>
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/format-icu/README.md
+++ b/packages/format-icu/README.md
@@ -146,7 +146,7 @@ In the `/packages/format-icu` directory.
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/i18next/README.md
+++ b/packages/i18next/README.md
@@ -151,7 +151,7 @@ In the `/packages/i18next` directory.
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/ngx/projects/ngx-tolgee/README.md
+++ b/packages/ngx/projects/ngx-tolgee/README.md
@@ -232,7 +232,7 @@ pnpm run e2e open ngx
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -193,7 +193,7 @@ pnpm run e2e open react
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -204,7 +204,7 @@ pnpm run e2e open svelte
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -229,7 +229,7 @@ pnpm run e2e open vue
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -167,7 +167,7 @@ pnpm run e2e open <integration>
 
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 

--- a/readmeMacros/macros.njk.md
+++ b/readmeMacros/macros.njk.md
@@ -87,14 +87,6 @@ Tolgee saves a lot of time you would spend on localization tasks otherwise. It e
 Read more on the [Tolgee website](https://tolgee.io)
 {% endmacro %}
 
-{% macro contributions() %}
-## Contributors
-
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
-  <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
-</a>
-{% endmacro %}
-
 {% macro developmentInstallation() %}
 We welcome your PRs.
 
@@ -165,7 +157,7 @@ pnpm run e2e open {{integration}}
 {% macro contributors() %}
 ## Contributors
 
-<a href="https://github.com/tolgee/tolgee-platform/graphs/contributors">
+<a href="https://github.com/tolgee/tolgee-js/graphs/contributors">
   <img alt="contributors" src="https://contrib.rocks/image?repo=tolgee/tolgee-js"/>
 </a>
 {% endmacro %}


### PR DESCRIPTION
## Summary

- The **Contributors** section in every README linked to `tolgee/tolgee-platform/graphs/contributors` instead of this repo's contributors graph (`tolgee/tolgee-js`), so clicking it took readers to the wrong project. Fixes #3432.
- Fixed the source Nunjucks macro `contributors()` in `readmeMacros/macros.njk.md` and regenerated all 9 READMEs (root + 8 packages). The contributors image (`contrib.rocks/image?repo=tolgee/tolgee-js`) was already correct and is unchanged.
- Removed an unused dead-duplicate macro `contributions()` that carried the same broken link, to prevent it being wired up later and reintroducing the bug.
- Note: the issue also mentioned broken links in a "Tolgee Rewards" section — that section no longer exists in the README, so no change was needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected contributor reference links in package documentation to direct to the Tolgee JS repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->