### PR TITLE
fix(web): keep base language visible in in-context dialog

### DIFF
--- a/packages/web/src/package/ui/KeyDialog/dialogContext/index.ts
+++ b/packages/web/src/package/ui/KeyDialog/dialogContext/index.ts
@@ -140,8 +140,11 @@ export const [DialogProvider, useDialogActions, useDialogContext] =
       },
       options: {
         onSuccess(data) {
+          const languages = data._embedded?.languages;
+          const baseTag = languages?.find((l) => l.base)?.tag;
           const selectedLanguages = getInitialLanguages(
-            data._embedded?.languages?.map((l) => l.tag!) || []
+            languages?.map((l) => l.tag!) || [],
+            baseTag
           );
           initializeWithDefaultValue(undefined, data._embedded?.languages);
           setSelectedLanguages(selectedLanguages);

--- a/packages/web/src/package/ui/KeyDialog/dialogContext/tools.test.ts
+++ b/packages/web/src/package/ui/KeyDialog/dialogContext/tools.test.ts
@@ -1,0 +1,47 @@
+import { MAX_LANGUAGES_SELECTED } from '../../../constants';
+import { getInitialLanguages, setPreferredLanguages } from './tools';
+
+describe('getInitialLanguages', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('puts the base language first in the fallback selection', () => {
+    const available = ['de', 'fr', 'en'];
+    expect(getInitialLanguages(available, 'en')).toEqual(['en', 'de', 'fr']);
+  });
+
+  it('caps the selection to MAX_LANGUAGES_SELECTED', () => {
+    const available = ['en', ...Array.from({ length: 10 }, (_, i) => `l${i}`)];
+    expect(getInitialLanguages(available, 'en')).toHaveLength(
+      MAX_LANGUAGES_SELECTED
+    );
+  });
+
+  it('includes the base language by default even when it sorts past the cap', () => {
+    const rawTags = ['ar', 'ar-PS', 'ar-SA', 'az', 'cs', 'de', 'en', 'es'];
+    const selected = getInitialLanguages(rawTags, 'en');
+    expect(selected[0]).toBe('en');
+    expect(selected).toHaveLength(MAX_LANGUAGES_SELECTED);
+  });
+
+  it('keeps the base language on top when a stored preference includes it past the cap', () => {
+    setPreferredLanguages(['ar', 'ar-PS', 'ar-SA', 'az', 'cs', 'en']);
+    const rawTags = ['ar', 'ar-PS', 'ar-SA', 'az', 'cs', 'en'];
+    const selected = getInitialLanguages(rawTags, 'en');
+    expect(selected[0]).toBe('en');
+    expect(selected).toHaveLength(MAX_LANGUAGES_SELECTED);
+  });
+
+  it('respects an explicit deselection of the base language', () => {
+    setPreferredLanguages(['cs', 'de']);
+    const rawTags = ['ar', 'cs', 'de', 'en'];
+    expect(getInitialLanguages(rawTags, 'en')).toEqual(['cs', 'de']);
+  });
+
+  it('does not duplicate the base language when it is already preferred', () => {
+    setPreferredLanguages(['en', 'cs']);
+    const rawTags = ['ar', 'cs', 'de', 'en'];
+    expect(getInitialLanguages(rawTags, 'en')).toEqual(['en', 'cs']);
+  });
+});

--- a/packages/web/src/package/ui/KeyDialog/dialogContext/tools.ts
+++ b/packages/web/src/package/ui/KeyDialog/dialogContext/tools.ts
@@ -5,6 +5,7 @@ import {
   MAX_LANGUAGES_SELECTED,
   PREFERRED_LANGUAGES_LOCAL_STORAGE_KEY,
 } from '../../../constants';
+import { putBaseLangFirstTags } from '../languageHelpers';
 
 export function getPreferredLanguages(): string[] {
   try {
@@ -23,13 +24,13 @@ export function setPreferredLanguages(languages: string[]) {
   );
 }
 
-export function getInitialLanguages(available: string[]) {
+export function getInitialLanguages(available: string[], base?: string) {
   const preferred = getPreferredLanguages();
   let langs = preferred.filter((l) => available.includes(l));
   if (langs.length === 0) {
     langs = available;
   }
-  return langs.slice(0, MAX_LANGUAGES_SELECTED);
+  return putBaseLangFirstTags(langs, base).slice(0, MAX_LANGUAGES_SELECTED);
 }
 
 export const changeInTolgeeCache = (

--- a/testapps/ngx/projects/sampleapp/src/app/pages/index/index.component.ts
+++ b/testapps/ngx/projects/sampleapp/src/app/pages/index/index.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NavbarComponent } from '../../component/navbar/navbar.component';
 import { FormsModule } from '@angular/forms';
 import { TDirective, TranslatePipe } from '@tolgee/ngx';
-import { NgOptimizedImage } from '@angular/common';
+import { isPlatformBrowser, NgOptimizedImage } from '@angular/common';
 
 @Component({
   selector: 'app-index',
@@ -21,8 +21,13 @@ export class IndexComponent implements OnInit {
   newItemValue: string;
   items: string[] = [];
 
+  constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
   getInitialItems() {
     let items: string[] | undefined = undefined;
+    if (!isPlatformBrowser(this.platformId)) {
+      return ['Passport', 'Maps and directions', 'Travel guide'];
+    }
     try {
       items = JSON.parse(
         localStorage.getItem('tolgee-example-app-items') || ''
@@ -32,9 +37,7 @@ export class IndexComponent implements OnInit {
       console.error(
         'Something went wrong while parsing stored items. Items are reset.'
       );
-      if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem('tolgee-example-app-items');
-      }
+      localStorage.removeItem('tolgee-example-app-items');
     }
     return items?.length
       ? items
@@ -64,9 +67,13 @@ export class IndexComponent implements OnInit {
     alert('action: ' + action);
   }
 
-  private updateLocalStorage = () =>
+  private updateLocalStorage = () => {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
     localStorage.setItem(
       'tolgee-example-app-items',
       JSON.stringify(this.items)
     );
+  };
 }


### PR DESCRIPTION
## Problem

When a project has more than 5 languages, opening the in-context translation dialog could omit the **base language** entirely. The initial language selection capped to the first 5 languages in raw API order, so the base language was sliced off whenever it sorted past position 5. Opening the dialog then persists the selection back to `localStorage`, so the truncated list (without the base language) was saved and the base language stayed hidden on every subsequent open. Since the base language is the translation reference, this made the dialog hard to use.

This reproduced on projects with many languages (e.g. base `en` behind Arabic/Azerbaijani/Czech in the API order). It appeared to "work" in some apps only because those origins had previously saved a preference that happened to include the base language — `localStorage` is per-origin, which masked the bug.

## Solution

Float the base language to the front of the initial selection **before** the cap is applied (`getInitialLanguages`), so it:

- is shown by default and on top when present,
- is never dropped by the 5-language cap.

An explicit deselection is still respected: if the user unchecks the base language, the stored preference omits it and it stays hidden on the next popup (per the discussion in the comments).

Added unit tests covering: base-first fallback ordering, the cap, default inclusion when the base sorts past the cap, keeping the base when a stored preference includes it past the cap, respecting an explicit deselection, and no duplication when already preferred.

## Note

This PR also includes an unrelated SSR fix in the `ngx` testapp (separate commit): the index component accessed `localStorage` during server-side rendering, throwing `localStorage.removeItem is not a function`. It's now guarded behind `isPlatformBrowser(PLATFORM_ID)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Language selection now prioritizes the configured base language while respecting saved preferences and selection limits.
  * Improved handling prevents duplicate language entries and preserves explicitly excluded preferences.

* **Bug Fixes**
  * Improved server-side rendering compatibility in the sample Angular app by preventing browser storage access outside the browser.

* **Tests**
  * Added coverage for base-language ordering, preference handling, limits, and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->