### PR TITLE
fix(react): allow explicit locale for static server rendering

### DIFF
--- a/packages/react/src/createServerInstance.spec.tsx
+++ b/packages/react/src/createServerInstance.spec.tsx
@@ -27,12 +27,22 @@ describe('createServerInstance', () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it('skips locale detection when an explicit locale is provided', async () => {
+  it('supports an explicit locale parameter object', async () => {
+    const { createTolgee, tolgee } = createTolgeeMock();
+    const getLocale = jest.fn().mockResolvedValue('en');
+    const { getTolgee } = createServerInstance({ createTolgee, getLocale });
+
+    await expect(getTolgee({ locale: 'cs' })).resolves.toBe(tolgee);
+    expect(getLocale).not.toHaveBeenCalled();
+    expect(createTolgee).toHaveBeenCalledWith('cs');
+  });
+
+  it('passes an explicit locale parameter object to translations', async () => {
     const { createTolgee, t } = createTolgeeMock();
     const getLocale = jest.fn().mockResolvedValue('en');
     const { getTranslate } = createServerInstance({ createTolgee, getLocale });
 
-    await expect(getTranslate('cs')).resolves.toBe(t);
+    await expect(getTranslate({ locale: 'cs' })).resolves.toBe(t);
     expect(getLocale).not.toHaveBeenCalled();
     expect(createTolgee).toHaveBeenCalledWith('cs');
   });

--- a/packages/react/src/createServerInstance.spec.tsx
+++ b/packages/react/src/createServerInstance.spec.tsx
@@ -36,4 +36,15 @@ describe('createServerInstance', () => {
     expect(getLocale).not.toHaveBeenCalled();
     expect(createTolgee).toHaveBeenCalledWith('cs');
   });
+
+  it('supports an explicit locale in the server T component', async () => {
+    const { createTolgee } = createTolgeeMock();
+    const getLocale = jest.fn().mockResolvedValue('en');
+    const { T } = createServerInstance({ createTolgee, getLocale });
+
+    await T({ keyName: 'hello', locale: 'cs' });
+
+    expect(getLocale).not.toHaveBeenCalled();
+    expect(createTolgee).toHaveBeenCalledWith('cs');
+  });
 });

--- a/packages/react/src/createServerInstance.spec.tsx
+++ b/packages/react/src/createServerInstance.spec.tsx
@@ -1,0 +1,39 @@
+import { TolgeeInstance } from '@tolgee/web';
+import { createServerInstance } from './createServerInstance';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  cache: (callback: unknown) => callback,
+}));
+
+describe('createServerInstance', () => {
+  const createTolgeeMock = () => {
+    const run = jest.fn().mockResolvedValue(undefined);
+    const t = jest.fn();
+    const tolgee = { run, t } as unknown as TolgeeInstance;
+    const createTolgee = jest.fn().mockResolvedValue(tolgee);
+
+    return { createTolgee, run, t, tolgee };
+  };
+
+  it('uses the configured locale resolver by default', async () => {
+    const { createTolgee, run, tolgee } = createTolgeeMock();
+    const getLocale = jest.fn().mockResolvedValue('en');
+    const { getTolgee } = createServerInstance({ createTolgee, getLocale });
+
+    await expect(getTolgee()).resolves.toBe(tolgee);
+    expect(getLocale).toHaveBeenCalledTimes(1);
+    expect(createTolgee).toHaveBeenCalledWith('en');
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips locale detection when an explicit locale is provided', async () => {
+    const { createTolgee, t } = createTolgeeMock();
+    const getLocale = jest.fn().mockResolvedValue('en');
+    const { getTranslate } = createServerInstance({ createTolgee, getLocale });
+
+    await expect(getTranslate('cs')).resolves.toBe(t);
+    expect(getLocale).not.toHaveBeenCalled();
+    expect(createTolgee).toHaveBeenCalledWith('cs');
+  });
+});

--- a/packages/react/src/createServerInstance.tsx
+++ b/packages/react/src/createServerInstance.tsx
@@ -16,6 +16,10 @@ type ServerTProps = TProps & {
   locale?: string;
 };
 
+type ServerFunctionOptions = {
+  locale?: string;
+};
+
 export const createServerInstance = ({
   createTolgee,
   getLocale,
@@ -28,19 +32,19 @@ export const createServerInstance = ({
     }
   );
 
-  const getTolgee = async (locale?: string) => {
+  const getTolgee = async ({ locale }: ServerFunctionOptions = {}) => {
     const resolvedLocale = locale ?? (await getLocale());
     const tolgee = await getTolgeeInstance(resolvedLocale);
     return tolgee;
   };
 
-  const getTranslate = async (locale?: string) => {
-    const tolgee = await getTolgee(locale);
+  const getTranslate = async ({ locale }: ServerFunctionOptions = {}) => {
+    const tolgee = await getTolgee({ locale });
     return tolgee.t;
   };
 
   async function T({ locale, ...props }: ServerTProps) {
-    const t = await getTranslate(locale);
+    const t = await getTranslate({ locale });
     return <TBase t={t as TFnType<ParamsTags>} {...props} />;
   }
 

--- a/packages/react/src/createServerInstance.tsx
+++ b/packages/react/src/createServerInstance.tsx
@@ -24,14 +24,14 @@ export const createServerInstance = ({
     }
   );
 
-  const getTolgee = async () => {
-    const locale = await getLocale();
-    const tolgee = await getTolgeeInstance(locale);
+  const getTolgee = async (locale?: string) => {
+    const resolvedLocale = locale ?? (await getLocale());
+    const tolgee = await getTolgeeInstance(resolvedLocale);
     return tolgee;
   };
 
-  const getTranslate = async () => {
-    const tolgee = await getTolgee();
+  const getTranslate = async (locale?: string) => {
+    const tolgee = await getTolgee(locale);
     return tolgee.t;
   };
 

--- a/packages/react/src/createServerInstance.tsx
+++ b/packages/react/src/createServerInstance.tsx
@@ -12,6 +12,10 @@ export type CreateServerInstanceOptions = {
   getLocale: () => Promise<string>;
 };
 
+type ServerTProps = TProps & {
+  locale?: string;
+};
+
 export const createServerInstance = ({
   createTolgee,
   getLocale,
@@ -35,8 +39,8 @@ export const createServerInstance = ({
     return tolgee.t;
   };
 
-  async function T(props: TProps) {
-    const t = await getTranslate();
+  async function T({ locale, ...props }: ServerTProps) {
+    const t = await getTranslate(locale);
     return <TBase t={t as TFnType<ParamsTags>} {...props} />;
   }
 

--- a/testapps/next-app-intl/README.md
+++ b/testapps/next-app-intl/README.md
@@ -29,7 +29,7 @@ When the locale is already available from route params, pass it directly to
 
 ```tsx
 const { locale } = await params;
-const tolgee = await getTolgee(locale);
+const tolgee = await getTolgee({ locale });
 ```
 
 This avoids running the configured request locale resolver during static

--- a/testapps/next-app-intl/README.md
+++ b/testapps/next-app-intl/README.md
@@ -21,3 +21,17 @@ NEXT_PUBLIC_TOLGEE_API_KEY=<your project API key>
 ```
 
 6. Re-run `npm run dev`
+
+## Static rendering
+
+When the locale is already available from route params, pass it directly to
+`getTolgee`:
+
+```tsx
+const { locale } = await params;
+const tolgee = await getTolgee(locale);
+```
+
+This avoids running the configured request locale resolver during static
+generation. The `/[locale]/ssg` route demonstrates this with
+`generateStaticParams`.

--- a/testapps/next-app-intl/src/app/[locale]/layout.tsx
+++ b/testapps/next-app-intl/src/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ export default async function LocaleLayout({ children, params }: Props) {
   if (!ALL_LANGUAGES.includes(locale)) {
     notFound();
   }
-  const tolgee = await getTolgee();
+  const tolgee = await getTolgee(locale);
   const records = await tolgee.loadRequired();
 
   return (

--- a/testapps/next-app-intl/src/app/[locale]/layout.tsx
+++ b/testapps/next-app-intl/src/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ export default async function LocaleLayout({ children, params }: Props) {
   if (!ALL_LANGUAGES.includes(locale)) {
     notFound();
   }
-  const tolgee = await getTolgee(locale);
+  const tolgee = await getTolgee({ locale });
   const records = await tolgee.loadRequired();
 
   return (

--- a/testapps/next-app-intl/src/app/[locale]/ssg/page.tsx
+++ b/testapps/next-app-intl/src/app/[locale]/ssg/page.tsx
@@ -1,0 +1,11 @@
+import { ALL_LANGUAGES } from '@/tolgee/shared';
+
+export const dynamic = 'error';
+
+export function generateStaticParams() {
+  return ALL_LANGUAGES.map((locale) => ({ locale }));
+}
+
+export default function StaticPage() {
+  return <div>Static page</div>;
+}


### PR DESCRIPTION
## Problem

Next.js App Router applications that already know the locale from route params still had to invoke the request-bound locale resolver. That resolver calls `headers()`, so otherwise deterministic `generateStaticParams` routes could not be rendered as SSG pages. This is the limitation confirmed in #3526.

## Solution

- allow `createServerInstance` callers to pass an explicit locale to `getTolgee` and `getTranslate`
- allow the server `T` component to accept an explicit locale while preserving every existing `TProps` field
- skip request-bound locale detection when an explicit locale is available
- add a Next App Router `generateStaticParams` regression route and example guidance

The API is additive; calls without a locale keep the existing resolver behavior.

## Verification

- `pnpm --filter @tolgee/react... build`
- `pnpm --filter @tolgee/react test`: 38/38 passed
- `pnpm --dir testapps/next-app-intl build`: emitted `/en/ssg`, `/cs/ssg`, `/de/ssg`, and `/fr/ssg` as SSG routes
- focused ESLint and Prettier checks
- `git diff --check`
- exact 2/2 range-diff after rebase onto current `main`
- independent API and SSG review completed with no blocking findings

Closes #3526.

## AI assistance

I used OpenAI Codex to assist with implementation, testing, and rebase validation. I reviewed and understand the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Server-side translation helpers now support an explicitly selected locale.
  - The server translation component can render content using a specified locale.
  - Added support and examples for statically generated, locale-specific pages.

- **Documentation**
  - Added guidance for using route-provided locales during static rendering.

- **Tests**
  - Added coverage for default and explicitly selected locale behavior across server translation APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->