### PR TITLE
feat: OAuth Bearer support for in-context editing

### DIFF
--- a/packages/core/src/Controller/Controller.ts
+++ b/packages/core/src/Controller/Controller.ts
@@ -317,9 +317,8 @@ export function Controller({ options }: StateServiceProps) {
     }) as TFnType,
 
     isDev() {
-      return Boolean(
-        state.getInitialOptions().apiKey && state.getInitialOptions().apiUrl
-      );
+      const options = state.getInitialOptions();
+      return Boolean((options.apiKey || options.authToken) && options.apiUrl);
     },
 
     async loadRequired(options?: LoadRequiredOptions) {

--- a/packages/core/src/Controller/Plugins/Plugins.ts
+++ b/packages/core/src/Controller/Plugins/Plugins.ts
@@ -198,7 +198,7 @@ export function Plugins(
         filterTag,
       } = getInitialOptions();
       instances.ui = plugins.ui?.({
-        apiKey: apiKey!,
+        apiKey,
         authToken,
         apiUrl: apiUrl!,
         projectId,

--- a/packages/core/src/Controller/Plugins/Plugins.ts
+++ b/packages/core/src/Controller/Plugins/Plugins.ts
@@ -189,6 +189,7 @@ export function Plugins(
     run() {
       const {
         apiKey,
+        authToken,
         apiUrl,
         projectId,
         branch,
@@ -198,6 +199,7 @@ export function Plugins(
       } = getInitialOptions();
       instances.ui = plugins.ui?.({
         apiKey: apiKey!,
+        authToken,
         apiUrl: apiUrl!,
         projectId,
         branch,
@@ -268,15 +270,16 @@ export function Plugins(
     }) as BackendGetRecordInternal,
 
     getBackendDevRecord: (async ({ language, namespace }) => {
-      const { apiKey, apiUrl, projectId, branch, filterTag } =
+      const { apiKey, authToken, apiUrl, projectId, branch, filterTag } =
         getInitialOptions();
 
-      if (!apiKey || !apiUrl || !self.hasDevBackend()) {
+      if ((!apiKey && !authToken) || !apiUrl || !self.hasDevBackend()) {
         return undefined;
       }
 
       return instances.devBackend?.getRecord({
         apiKey,
+        authToken,
         apiUrl,
         projectId,
         branch,

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -75,7 +75,7 @@ export function State(
 
     getInitialOptions() {
       const merged = { ...state.initialOptions, ...devCredentials };
-      // A dev-credentials override fully determines the auth method, clearing the base layer's other credential.
+      // An override's auth method replaces the base's; without this a partial override leaves both fields set.
       if (
         devCredentials &&
         (devCredentials.apiKey || devCredentials.authToken)

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -75,8 +75,7 @@ export function State(
 
     getInitialOptions() {
       const merged = { ...state.initialOptions, ...devCredentials };
-      // A dev-credentials override fully determines the auth method, so a stale init `authToken` can't out-precede a
-      // freshly-injected `apiKey` (which Bearer precedence would otherwise pick).
+      // A dev-credentials override fully determines the auth method, clearing the base layer's other credential.
       if (
         devCredentials &&
         (devCredentials.apiKey || devCredentials.authToken)

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -75,9 +75,8 @@ export function State(
 
     getInitialOptions() {
       const merged = { ...state.initialOptions, ...devCredentials };
-      // A dev-credentials override (the extension's in-context injection) fully determines the auth method: otherwise a
-      // statically-configured init `authToken` would out-precede a freshly-injected `apiKey` (Bearer wins in
-      // resolveCredential), so the stale token would beat the credential the user actually selected.
+      // A dev-credentials override fully determines the auth method, so a stale init `authToken` can't out-precede a
+      // freshly-injected `apiKey` (which Bearer precedence would otherwise pick).
       if (
         devCredentials &&
         (devCredentials.apiKey || devCredentials.authToken)

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -74,7 +74,18 @@ export function State(
     },
 
     getInitialOptions() {
-      return { ...state.initialOptions, ...devCredentials };
+      const merged = { ...state.initialOptions, ...devCredentials };
+      // A dev-credentials override (the extension's in-context injection) fully determines the auth method: otherwise a
+      // statically-configured init `authToken` would out-precede a freshly-injected `apiKey` (Bearer wins in
+      // resolveCredential), so the stale token would beat the credential the user actually selected.
+      if (
+        devCredentials &&
+        (devCredentials.apiKey || devCredentials.authToken)
+      ) {
+        merged.apiKey = devCredentials.apiKey;
+        merged.authToken = devCredentials.authToken;
+      }
+      return merged;
     },
 
     addActiveNs(ns: NsFallback) {

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -75,7 +75,7 @@ export function State(
 
     getInitialOptions() {
       const merged = { ...state.initialOptions, ...devCredentials };
-      // An override's auth method replaces the base's (both fields taken from the override).
+      // Clear the base's other credential — a plain merge would leave both auth fields set and pick the wrong one.
       if (
         devCredentials &&
         (devCredentials.apiKey || devCredentials.authToken)

--- a/packages/core/src/Controller/State/State.ts
+++ b/packages/core/src/Controller/State/State.ts
@@ -75,7 +75,7 @@ export function State(
 
     getInitialOptions() {
       const merged = { ...state.initialOptions, ...devCredentials };
-      // An override's auth method replaces the base's; without this a partial override leaves both fields set.
+      // An override's auth method replaces the base's (both fields taken from the override).
       if (
         devCredentials &&
         (devCredentials.apiKey || devCredentials.authToken)

--- a/packages/core/src/Controller/State/initState.ts
+++ b/packages/core/src/Controller/State/initState.ts
@@ -43,7 +43,13 @@ export type TolgeeOptionsInternal = {
   apiKey?: string;
 
   /**
-   * Project id is necessary if you are using PAT
+   * OAuth 2.1 access token, sent as `Authorization: Bearer`. An alternative to `apiKey`, typically supplied by the
+   * Tolgee browser extension. Carries no embedded project, so `projectId` is required when using it.
+   */
+  authToken?: string;
+
+  /**
+   * Project id is necessary if you are using PAT or an OAuth access token
    */
   projectId?: number | string;
 

--- a/packages/core/src/Controller/State/initState.ts
+++ b/packages/core/src/Controller/State/initState.ts
@@ -49,7 +49,9 @@ export type TolgeeOptionsInternal = {
   authToken?: string;
 
   /**
-   * Project id is necessary if you are using PAT or an OAuth access token
+   * Project id is necessary if you are using PAT or an OAuth access token, and is required by the Tolgee browser
+   * extension to connect in-context editing (it cannot be derived from an OAuth token the way it is from a PAK).
+   * See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid
    */
   projectId?: number | string;
 

--- a/packages/core/src/Controller/State/initState.ts
+++ b/packages/core/src/Controller/State/initState.ts
@@ -44,9 +44,7 @@ export type TolgeeOptionsInternal = {
 
   /**
    * OAuth 2.1 access token, sent as `Authorization: Bearer`. An alternative to `apiKey`, typically supplied by the
-   * Tolgee browser extension. Carries no embedded project, so `projectId` is required when using it. Note: when the
-   * browser extension has injected a (rotating) token into `sessionStorage`, that live token takes precedence over this
-   * one, so in-context editing keeps working after the token rotates.
+   * Tolgee browser extension. Carries no embedded project, so `projectId` is required when using it.
    */
   authToken?: string;
 

--- a/packages/core/src/Controller/State/initState.ts
+++ b/packages/core/src/Controller/State/initState.ts
@@ -44,13 +44,15 @@ export type TolgeeOptionsInternal = {
 
   /**
    * OAuth 2.1 access token, sent as `Authorization: Bearer`. An alternative to `apiKey`, typically supplied by the
-   * Tolgee browser extension. Carries no embedded project, so `projectId` is required when using it.
+   * Tolgee browser extension. Carries no embedded project, so `projectId` is required when using it. Note: when the
+   * browser extension has injected a (rotating) token into `sessionStorage`, that live token takes precedence over this
+   * one, so in-context editing keeps working after the token rotates.
    */
   authToken?: string;
 
   /**
    * Project id is necessary if you are using PAT or an OAuth access token, and is required by the Tolgee browser
-   * extension to connect in-context editing (it cannot be derived from an OAuth token the way it is from a PAK).
+   * extension to connect in-context editing.
    * See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid
    */
   projectId?: number | string;

--- a/packages/core/src/TolgeeCore.ts
+++ b/packages/core/src/TolgeeCore.ts
@@ -184,7 +184,7 @@ function createTolgee(options: TolgeeOptions) {
     getInitialOptions: controller.getInitialOptions,
 
     /**
-     * Tolgee is in dev mode if `DevTools` plugin is used and `apiKey` + `apiUrl` are specified.
+     * Tolgee is in dev mode if `DevTools` plugin is used and (`apiKey` or `authToken`) + `apiUrl` are specified.
      * @return `true` if tolgee is in dev mode.
      */
     isDev: controller.isDev,

--- a/packages/core/src/__test/helpers.test.ts
+++ b/packages/core/src/__test/helpers.test.ts
@@ -1,0 +1,30 @@
+import { createFetchFunction } from '../helpers';
+
+describe('createFetchFunction SDK headers', () => {
+  const wrappedHeaders = (init?: RequestInit) => {
+    const inner = jest.fn(() =>
+      Promise.resolve({} as unknown as Response)
+    ) as any;
+    createFetchFunction(inner)('http://x', init);
+    return inner.mock.calls[0][1].headers as Record<string, string>;
+  };
+
+  it('adds SDK type/version headers for an X-API-Key request', () => {
+    const headers = wrappedHeaders({ headers: { 'x-api-key': 'tgpak_x' } });
+    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
+    expect(headers['x-tolgee-sdk-version']).toBeDefined();
+  });
+
+  it('adds SDK type/version headers for a Bearer Authorization request', () => {
+    const headers = wrappedHeaders({
+      headers: { authorization: 'Bearer jwt' },
+    });
+    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
+    expect(headers['x-tolgee-sdk-version']).toBeDefined();
+  });
+
+  it('does not add SDK headers when no auth header is present', () => {
+    const headers = wrappedHeaders({ headers: { 'content-type': 'x' } });
+    expect(headers['x-tolgee-sdk-type']).toBeUndefined();
+  });
+});

--- a/packages/core/src/__test/helpers.test.ts
+++ b/packages/core/src/__test/helpers.test.ts
@@ -15,12 +15,12 @@ describe('createFetchFunction SDK headers', () => {
     expect(headers['x-tolgee-sdk-version']).toBeDefined();
   });
 
-  it('adds SDK type/version headers for a Bearer Authorization request', () => {
+  it('does not add SDK headers for a bare Authorization request (BackendFetch may target a third-party host)', () => {
     const headers = wrappedHeaders({
       headers: { authorization: 'Bearer jwt' },
     });
-    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
-    expect(headers['x-tolgee-sdk-version']).toBeDefined();
+    expect(headers['x-tolgee-sdk-type']).toBeUndefined();
+    expect(headers['x-tolgee-sdk-version']).toBeUndefined();
   });
 
   it('does not add SDK headers when no auth header is present', () => {

--- a/packages/core/src/__test/helpers.test.ts
+++ b/packages/core/src/__test/helpers.test.ts
@@ -26,5 +26,6 @@ describe('createFetchFunction SDK headers', () => {
   it('does not add SDK headers when no auth header is present', () => {
     const headers = wrappedHeaders({ headers: { 'content-type': 'x' } });
     expect(headers['x-tolgee-sdk-type']).toBeUndefined();
+    expect(headers['x-tolgee-sdk-version']).toBeUndefined();
   });
 });

--- a/packages/core/src/__test/isDev.test.ts
+++ b/packages/core/src/__test/isDev.test.ts
@@ -16,4 +16,16 @@ describe('isDev', () => {
   it('is false with no credential', () => {
     expect(TolgeeCore().init({ apiUrl: 'http://x' }).isDev()).toBe(false);
   });
+
+  it('is false with an OAuth token but no apiUrl', () => {
+    expect(TolgeeCore().init({ authToken: 'jwt', apiUrl: '' }).isDev()).toBe(
+      false
+    );
+  });
+
+  it('is false with an api key but no apiUrl', () => {
+    expect(TolgeeCore().init({ apiKey: 'tgpak_x', apiUrl: '' }).isDev()).toBe(
+      false
+    );
+  });
 });

--- a/packages/core/src/__test/isDev.test.ts
+++ b/packages/core/src/__test/isDev.test.ts
@@ -1,0 +1,19 @@
+import { TolgeeCore } from '../TolgeeCore';
+
+describe('isDev', () => {
+  it('is true with an api key and apiUrl', () => {
+    expect(
+      TolgeeCore().init({ apiKey: 'tgpak_x', apiUrl: 'http://x' }).isDev()
+    ).toBe(true);
+  });
+
+  it('is true with an OAuth token and apiUrl (no api key)', () => {
+    expect(
+      TolgeeCore().init({ authToken: 'jwt', apiUrl: 'http://x' }).isDev()
+    ).toBe(true);
+  });
+
+  it('is false with no credential', () => {
+    expect(TolgeeCore().init({ apiUrl: 'http://x' }).isDev()).toBe(false);
+  });
+});

--- a/packages/core/src/__test/options.test.ts
+++ b/packages/core/src/__test/options.test.ts
@@ -111,6 +111,24 @@ describe('initial options', () => {
     expect(options.authToken).toBeUndefined();
   });
 
+  it('an override without a credential preserves the init auth method', () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'http://localhost:8080',
+      authToken: 'jwt',
+    });
+
+    tolgee.overrideCredentials({
+      apiUrl: 'http://localhost:8000',
+      branch: 'feature',
+    });
+
+    const options = tolgee.getInitialOptions();
+    expect(options.authToken).toEqual('jwt');
+    expect(options.apiKey).toBeUndefined();
+    expect(options.branch).toEqual('feature');
+  });
+
   it('an injected authToken fully replaces a statically-configured apiKey', () => {
     const tolgee = TolgeeCore().init({
       language: 'en',

--- a/packages/core/src/__test/options.test.ts
+++ b/packages/core/src/__test/options.test.ts
@@ -92,4 +92,40 @@ describe('initial options', () => {
 
     expect(tolgee.getInitialOptions().branch).toEqual('override');
   });
+
+  it('an injected apiKey fully replaces a statically-configured authToken', () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'http://localhost:8080',
+      authToken: 'jwt',
+    });
+
+    tolgee.overrideCredentials({
+      apiUrl: 'http://localhost:8000',
+      apiKey: 'tgpak_x',
+      projectId: 1,
+    });
+
+    const options = tolgee.getInitialOptions();
+    expect(options.apiKey).toEqual('tgpak_x');
+    expect(options.authToken).toBeUndefined();
+  });
+
+  it('an injected authToken fully replaces a statically-configured apiKey', () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'http://localhost:8080',
+      apiKey: 'tgpak_x',
+    });
+
+    tolgee.overrideCredentials({
+      apiUrl: 'http://localhost:8000',
+      authToken: 'jwt',
+      projectId: 1,
+    });
+
+    const options = tolgee.getInitialOptions();
+    expect(options.authToken).toEqual('jwt');
+    expect(options.apiKey).toBeUndefined();
+  });
 });

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -113,15 +113,21 @@ function headersInitToRecord(headersInit?: HeadersInit | undefined) {
   return Object.fromEntries(new Headers(headersInit).entries());
 }
 
+export const sdkHeaders = (): Record<string, string> => ({
+  'x-tolgee-sdk-type': 'JS',
+  'x-tolgee-sdk-version': process.env.TOLGEE_UI_VERSION || 'prerelease',
+});
+
 export const createFetchFunction = (
   fetchFn: FetchFn = defaultFetchFunction
 ): FetchFn => {
   return (input, init) => {
     let headers = headersInitToRecord(init?.headers);
-    if (headers['x-api-key'] || headers['authorization']) {
+    // Key off the Tolgee-proprietary x-api-key only: this shared wrapper also fronts BackendFetch, which forwards a
+    // user's Authorization header to a third-party CDN. Bearer requests to Tolgee attach the sdk headers in the web layer.
+    if (headers['x-api-key']) {
       headers = {
-        'x-tolgee-sdk-type': 'JS',
-        'x-tolgee-sdk-version': process.env.TOLGEE_UI_VERSION || 'prerelease',
+        ...sdkHeaders(),
         ...headers,
       };
     }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -118,7 +118,7 @@ export const createFetchFunction = (
 ): FetchFn => {
   return (input, init) => {
     let headers = headersInitToRecord(init?.headers);
-    if (headers['x-api-key']) {
+    if (headers['x-api-key'] || headers['authorization']) {
       headers = {
         'x-tolgee-sdk-type': 'JS',
         'x-tolgee-sdk-version': process.env.TOLGEE_UI_VERSION || 'prerelease',

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -123,8 +123,8 @@ export const createFetchFunction = (
 ): FetchFn => {
   return (input, init) => {
     let headers = headersInitToRecord(init?.headers);
-    // Key off the Tolgee-proprietary x-api-key only: this shared wrapper also fronts BackendFetch, which forwards a
-    // user's Authorization header to a third-party CDN. Bearer requests to Tolgee attach the sdk headers in the web layer.
+    // Key off the Tolgee-proprietary x-api-key only — this shared wrapper also fronts BackendFetch, which forwards a
+    // user's Authorization header to a third-party CDN that must not receive these headers.
     if (headers['x-api-key']) {
       headers = {
         ...sdkHeaders(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,9 @@
-export { getFallback, getFallbackArray, createFetchFunction } from './helpers';
+export {
+  getFallback,
+  getFallbackArray,
+  createFetchFunction,
+  sdkHeaders,
+} from './helpers';
 export { encodeCacheKey } from './Controller/Cache/helpers';
 export { TolgeeCore } from './TolgeeCore';
 export * from './types';

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -158,7 +158,7 @@ export type KeyPosition = {
 
 export type UiProps = {
   apiUrl: string;
-  apiKey: string;
+  apiKey?: string;
   authToken?: string;
   projectId: number | string | undefined;
   branch?: string;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -13,6 +13,7 @@ import { TranslationDescriptor } from './events';
 export type BackendDevProps = {
   apiUrl?: string;
   apiKey?: string;
+  authToken?: string;
   projectId?: number | string;
   branch?: string;
   filterTag?: string[];
@@ -110,6 +111,7 @@ export type DevCredentials =
   | {
       apiUrl?: string;
       apiKey?: string;
+      authToken?: string;
       projectId?: string | number;
       branch?: string;
     };
@@ -157,6 +159,7 @@ export type KeyPosition = {
 export type UiProps = {
   apiUrl: string;
   apiKey: string;
+  authToken?: string;
   projectId: number | string | undefined;
   branch?: string;
   highlight: HighlightInterface;

--- a/packages/web/rollup.common.ts
+++ b/packages/web/rollup.common.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { RollupOptions, OutputOptions, ModuleFormat } from 'rollup';
 
 //@ts-ignore

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -1,13 +1,14 @@
 import type { TolgeePlugin } from '@tolgee/core';
 import { Handshaker } from '../tools/extension';
+import { resolveCredential } from '../tools/auth';
+import {
+  API_KEY_LOCAL_STORAGE,
+  API_URL_LOCAL_STORAGE,
+  AUTH_TOKEN_LOCAL_STORAGE,
+  BRANCH_LOCAL_STORAGE,
+  PROJECT_ID_LOCAL_STORAGE,
+} from '../tools/sessionStorageKeys';
 import { loadInContextLib } from './loadInContextLib';
-import { AUTH_TOKEN_LOCAL_STORAGE } from './constants';
-
-export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
-export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
-export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
-export { AUTH_TOKEN_LOCAL_STORAGE };
-export const PROJECT_ID_LOCAL_STORAGE = '__tolgee_projectId';
 
 function getCredentials() {
   const apiKey = sessionStorage.getItem(API_KEY_LOCAL_STORAGE) || undefined;
@@ -18,22 +19,20 @@ function getCredentials() {
   const projectId =
     sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
 
-  // Either a static api key or an OAuth access token is enough to authenticate against the backend.
   if ((!apiKey && !authToken) || !apiUrl) {
     return undefined;
   }
 
   return {
-    apiKey,
     apiUrl,
+    ...(apiKey !== undefined ? { apiKey } : {}),
     ...(authToken !== undefined ? { authToken } : {}),
-    // OAuth access tokens carry no embedded project (unlike a PAK), so the extension supplies the id explicitly.
     ...(projectId !== undefined ? { projectId } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };
 }
 
-function clearSessionStorage() {
+export function clearSessionStorage() {
   sessionStorage.removeItem(API_KEY_LOCAL_STORAGE);
   sessionStorage.removeItem(API_URL_LOCAL_STORAGE);
   sessionStorage.removeItem(BRANCH_LOCAL_STORAGE);
@@ -76,8 +75,9 @@ const sessionStorageAvailable = () => {
 if (sessionStorageAvailable()) {
   BrowserExtensionPlugin = (): TolgeePlugin => (tolgee) => {
     const handshaker = Handshaker();
-    const getConfig = () =>
-      ({
+    const getConfig = () => {
+      const options = tolgee.getInitialOptions();
+      return {
         // prevent extension downloading ui library
         uiPresent: true,
         uiVersion: undefined,
@@ -85,13 +85,14 @@ if (sessionStorageAvailable()) {
         mode: tolgee.isDev() ? 'development' : 'production',
         // pass credentials
         config: {
-          apiUrl: tolgee.getInitialOptions().apiUrl || '',
-          apiKey: tolgee.getInitialOptions().apiKey || '',
-          authToken: tolgee.getInitialOptions().authToken,
-          projectId: tolgee.getInitialOptions().projectId,
-          branch: tolgee.getInitialOptions().branch,
+          apiUrl: options.apiUrl || '',
+          apiKey: options.apiKey || '',
+          authToken: options.authToken,
+          projectId: options.projectId,
+          branch: options.branch,
         },
-      }) as const;
+      } as const;
+    };
 
     const getTolgeePlugin = async (): Promise<TolgeePlugin> => {
       const InContextTools = await loadInContextLib(
@@ -104,11 +105,21 @@ if (sessionStorageAvailable()) {
       };
     };
 
-    if (tolgee.getInitialOptions().projectId === undefined) {
+    // Ask the same authority the fetch paths use, folding in the extension-injected projectId, so the advisory can't
+    // disagree with whether a request will actually require an explicit project.
+    const options = tolgee.getInitialOptions();
+    const injectedProjectId =
+      sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
+    const { requiresExplicitProject, projectId } = resolveCredential({
+      apiKey: options.apiKey,
+      authToken: options.authToken,
+      projectId: options.projectId ?? injectedProjectId,
+    });
+    if (tolgee.isDev() && requiresExplicitProject && projectId === undefined) {
       // eslint-disable-next-line no-console
       console.warn(
         'Tolgee: `projectId` is missing from the SDK configuration. The Tolgee browser extension needs it to ' +
-          'connect in-context editing (an OAuth token carries no embedded project). ' +
+          'connect in-context editing. ' +
           'See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid'
       );
     }

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -1,11 +1,12 @@
 import type { TolgeePlugin } from '@tolgee/core';
 import { Handshaker } from '../tools/extension';
 import { loadInContextLib } from './loadInContextLib';
+import { AUTH_TOKEN_LOCAL_STORAGE } from './constants';
 
 export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
 export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
 export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
-export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';
+export { AUTH_TOKEN_LOCAL_STORAGE };
 export const PROJECT_ID_LOCAL_STORAGE = '__tolgee_projectId';
 
 function getCredentials() {

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -2,28 +2,27 @@ import type { TolgeePlugin } from '@tolgee/core';
 import { Handshaker } from '../tools/extension';
 import { resolveCredential } from '../tools/auth';
 import {
-  API_KEY_LOCAL_STORAGE,
-  API_URL_LOCAL_STORAGE,
-  AUTH_TOKEN_LOCAL_STORAGE,
-  BRANCH_LOCAL_STORAGE,
-  PROJECT_ID_LOCAL_STORAGE,
+  API_KEY_SESSION_STORAGE,
+  API_URL_SESSION_STORAGE,
+  AUTH_TOKEN_SESSION_STORAGE,
+  BRANCH_SESSION_STORAGE,
+  PROJECT_ID_SESSION_STORAGE,
 } from '../tools/sessionStorageKeys';
 import { loadInContextLib } from './loadInContextLib';
 
 function getCredentials() {
-  const apiKey = sessionStorage.getItem(API_KEY_LOCAL_STORAGE) || undefined;
-  const apiUrl = sessionStorage.getItem(API_URL_LOCAL_STORAGE) || undefined;
-  const branch = sessionStorage.getItem(BRANCH_LOCAL_STORAGE) || undefined;
+  const apiKey = sessionStorage.getItem(API_KEY_SESSION_STORAGE) || undefined;
+  const apiUrl = sessionStorage.getItem(API_URL_SESSION_STORAGE) || undefined;
+  const branch = sessionStorage.getItem(BRANCH_SESSION_STORAGE) || undefined;
   const authToken =
-    sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE) || undefined;
+    sessionStorage.getItem(AUTH_TOKEN_SESSION_STORAGE) || undefined;
   const projectId =
-    sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
+    sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
 
-  // An OAuth token authorizes in-context editing only with an explicit projectId (it carries none, unlike a PAK). A
-  // bare token is unusable, so don't treat it as a credential or pass it on: the fetch paths would otherwise pick the
-  // Bearer token over a working PAK on the same page and fail every request for want of a project.
+  // A bare OAuth token (no projectId) is unusable and must not be passed on, or the fetch paths pick the Bearer token
+  // over a working PAK and fail every request for want of a project.
   const oauthUsable = Boolean(authToken && projectId);
-  if (!apiKey && !oauthUsable) {
+  if (!apiUrl || (!apiKey && !oauthUsable)) {
     return undefined;
   }
 
@@ -37,11 +36,35 @@ function getCredentials() {
 }
 
 export function clearSessionStorage() {
-  sessionStorage.removeItem(API_KEY_LOCAL_STORAGE);
-  sessionStorage.removeItem(API_URL_LOCAL_STORAGE);
-  sessionStorage.removeItem(BRANCH_LOCAL_STORAGE);
-  sessionStorage.removeItem(AUTH_TOKEN_LOCAL_STORAGE);
-  sessionStorage.removeItem(PROJECT_ID_LOCAL_STORAGE);
+  sessionStorage.removeItem(API_KEY_SESSION_STORAGE);
+  sessionStorage.removeItem(API_URL_SESSION_STORAGE);
+  sessionStorage.removeItem(BRANCH_SESSION_STORAGE);
+  sessionStorage.removeItem(AUTH_TOKEN_SESSION_STORAGE);
+  sessionStorage.removeItem(PROJECT_ID_SESSION_STORAGE);
+}
+
+// resolveCredential reads the live (extension-injected) token itself; we only supply the injected projectId, which it
+// does not read, so the advisory doesn't fire on a PAK-configured page that merely has a stray injected token.
+function warnIfProjectIdMissing(tolgee: Parameters<TolgeePlugin>[0]) {
+  if (!tolgee.isDev()) {
+    return;
+  }
+  const options = tolgee.getInitialOptions();
+  const injectedProjectId =
+    sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
+  const { requiresExplicitProject, projectId } = resolveCredential({
+    apiKey: options.apiKey,
+    authToken: options.authToken,
+    projectId: options.projectId ?? injectedProjectId,
+  });
+  if (requiresExplicitProject && projectId === undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Tolgee: `projectId` is missing from the SDK configuration. The Tolgee browser extension needs it to ' +
+        'connect in-context editing. ' +
+        'See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid'
+    );
+  }
 }
 
 function onDocumentReady(callback: () => void) {
@@ -109,27 +132,7 @@ if (sessionStorageAvailable()) {
       };
     };
 
-    // Ask the same authority the fetch paths use, folding in the extension-injected token and projectId, so the
-    // advisory can't disagree with whether a request will actually require an explicit project. Without the injected
-    // token, an OAuth session injected without a projectId (e.g. onto a PAK-configured page) would warn about nothing.
-    const options = tolgee.getInitialOptions();
-    const injectedAuthToken =
-      sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE) || undefined;
-    const injectedProjectId =
-      sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
-    const { requiresExplicitProject, projectId } = resolveCredential({
-      apiKey: options.apiKey,
-      authToken: options.authToken ?? injectedAuthToken,
-      projectId: options.projectId ?? injectedProjectId,
-    });
-    if (tolgee.isDev() && requiresExplicitProject && projectId === undefined) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Tolgee: `projectId` is missing from the SDK configuration. The Tolgee browser extension needs it to ' +
-          'connect in-context editing. ' +
-          'See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid'
-      );
-    }
+    warnIfProjectIdMissing(tolgee);
 
     tolgee.on('running', ({ value: isRunning }) => {
       if (isRunning) {

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -19,8 +19,7 @@ function getCredentials() {
   const projectId =
     sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
 
-  // A bare OAuth token (no projectId) is unusable and must not be passed on, or the fetch paths pick the Bearer token
-  // over a working PAK and fail every request for want of a project.
+  // A bare OAuth token (no projectId) is unusable — withhold it so the fetch paths don't pick it over a working PAK.
   const oauthUsable = Boolean(authToken && projectId);
   if (!apiUrl || (!apiKey && !oauthUsable)) {
     return undefined;
@@ -43,20 +42,15 @@ export function clearSessionStorage() {
   sessionStorage.removeItem(PROJECT_ID_SESSION_STORAGE);
 }
 
-// resolveCredential reads the live (extension-injected) token itself; we only supply the injected projectId, which it
-// does not read, so the advisory doesn't fire on a PAK-configured page that merely has a stray injected token.
+// Warn on the SDK's own config: its DevBackend/client requests derive projectId only from init options, so an injected
+// projectId (which only the in-context UMD reads) must not silence a warning about a config that will still fail.
 function warnIfProjectIdMissing(tolgee: Parameters<TolgeePlugin>[0]) {
   if (!tolgee.isDev()) {
     return;
   }
-  const options = tolgee.getInitialOptions();
-  const injectedProjectId =
-    sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
-  const { requiresExplicitProject, projectId } = resolveCredential({
-    apiKey: options.apiKey,
-    authToken: options.authToken,
-    projectId: options.projectId ?? injectedProjectId,
-  });
+  const { requiresExplicitProject, projectId } = resolveCredential(
+    tolgee.getInitialOptions()
+  );
   if (requiresExplicitProject && projectId === undefined) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -5,19 +5,24 @@ import { loadInContextLib } from './loadInContextLib';
 export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
 export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
 export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
+export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';
 
 function getCredentials() {
   const apiKey = sessionStorage.getItem(API_KEY_LOCAL_STORAGE) || undefined;
   const apiUrl = sessionStorage.getItem(API_URL_LOCAL_STORAGE) || undefined;
   const branch = sessionStorage.getItem(BRANCH_LOCAL_STORAGE) || undefined;
+  const authToken =
+    sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE) || undefined;
 
-  if (!apiKey || !apiUrl) {
+  // Either a static api key or an OAuth access token is enough to authenticate against the backend.
+  if ((!apiKey && !authToken) || !apiUrl) {
     return undefined;
   }
 
   return {
     apiKey,
     apiUrl,
+    ...(authToken !== undefined ? { authToken } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };
 }
@@ -26,6 +31,7 @@ function clearSessionStorage() {
   sessionStorage.removeItem(API_KEY_LOCAL_STORAGE);
   sessionStorage.removeItem(API_URL_LOCAL_STORAGE);
   sessionStorage.removeItem(BRANCH_LOCAL_STORAGE);
+  sessionStorage.removeItem(AUTH_TOKEN_LOCAL_STORAGE);
 }
 
 function onDocumentReady(callback: () => void) {
@@ -74,6 +80,7 @@ if (sessionStorageAvailable()) {
         config: {
           apiUrl: tolgee.getInitialOptions().apiUrl || '',
           apiKey: tolgee.getInitialOptions().apiKey || '',
+          authToken: tolgee.getInitialOptions().authToken,
           branch: tolgee.getInitialOptions().branch,
         },
       }) as const;

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -19,14 +19,18 @@ function getCredentials() {
   const projectId =
     sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
 
-  if ((!apiKey && !authToken) || !apiUrl) {
+  // An OAuth token authorizes in-context editing only with an explicit projectId (it carries none, unlike a PAK). A
+  // bare token is unusable, so don't treat it as a credential or pass it on: the fetch paths would otherwise pick the
+  // Bearer token over a working PAK on the same page and fail every request for want of a project.
+  const oauthUsable = Boolean(authToken && projectId);
+  if (!apiKey && !oauthUsable) {
     return undefined;
   }
 
   return {
     apiUrl,
     ...(apiKey !== undefined ? { apiKey } : {}),
-    ...(authToken !== undefined ? { authToken } : {}),
+    ...(oauthUsable ? { authToken } : {}),
     ...(projectId !== undefined ? { projectId } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -104,6 +104,15 @@ if (sessionStorageAvailable()) {
       };
     };
 
+    if (tolgee.getInitialOptions().projectId === undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Tolgee: `projectId` is missing from the SDK configuration. The Tolgee browser extension needs it to ' +
+          'connect in-context editing (an OAuth token carries no embedded project). ' +
+          'See https://docs.tolgee.io/js-sdk/api/core_package/options#projectid'
+      );
+    }
+
     tolgee.on('running', ({ value: isRunning }) => {
       if (isRunning) {
         onDocumentReady(() => {

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -1,6 +1,6 @@
 import type { TolgeePlugin } from '@tolgee/core';
 import { Handshaker } from '../tools/extension';
-import { resolveCredential } from '../tools/auth';
+import { buildAuthHeader, resolveCredential } from '../tools/auth';
 import {
   API_KEY_SESSION_STORAGE,
   API_URL_SESSION_STORAGE,
@@ -24,9 +24,8 @@ function getCredentials() {
     return undefined;
   }
 
-  // The OAuth token is deliberately NOT forwarded into the credentials: the in-context requests read it live from
-  // sessionStorage (resolveLiveAuthToken), so once the extension clears a revoked session the token stops — a snapshot
-  // here would live on in devCredentials and keep sending the dead token.
+  // The OAuth token is deliberately NOT forwarded here — a snapshot would live on in devCredentials and keep sending a
+  // revoked token after the extension clears the session (the token is read live per request instead).
   return {
     apiUrl,
     ...(apiKey !== undefined ? { apiKey } : {}),
@@ -97,9 +96,9 @@ if (sessionStorageAvailable()) {
     const handshaker = Handshaker();
     const getConfig = () => {
       const options = tolgee.getInitialOptions();
-      // Forward only the auth method resolveCredential selects, so the extension never re-decides precedence.
+      // Decide the winning auth method from the same snapshot we forward, so the flag and the forwarded value agree.
       const usingToken = Boolean(
-        resolveCredential(options).authHeader.Authorization
+        buildAuthHeader(options.authToken, options.apiKey).Authorization
       );
       return {
         // prevent extension downloading ui library

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -96,6 +96,11 @@ if (sessionStorageAvailable()) {
     const handshaker = Handshaker();
     const getConfig = () => {
       const options = tolgee.getInitialOptions();
+      // Forward only the auth method resolveCredential actually selects, so the extension never has to re-decide
+      // precedence between a coexisting apiKey and authToken.
+      const usingToken = Boolean(
+        resolveCredential(options).authHeader.Authorization
+      );
       return {
         // prevent extension downloading ui library
         uiPresent: true,
@@ -105,8 +110,8 @@ if (sessionStorageAvailable()) {
         // pass credentials
         config: {
           apiUrl: options.apiUrl || '',
-          apiKey: options.apiKey || '',
-          authToken: options.authToken,
+          apiKey: usingToken ? '' : options.apiKey || '',
+          authToken: usingToken ? options.authToken : undefined,
           projectId: options.projectId,
           branch: options.branch,
         },

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -19,16 +19,17 @@ function getCredentials() {
   const projectId =
     sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
 
-  // A bare OAuth token (no projectId) is unusable — withhold it so the fetch paths don't pick it over a working PAK.
   const oauthUsable = Boolean(authToken && projectId);
   if (!apiUrl || (!apiKey && !oauthUsable)) {
     return undefined;
   }
 
+  // The OAuth token is deliberately NOT forwarded into the credentials: the in-context requests read it live from
+  // sessionStorage (resolveLiveAuthToken), so once the extension clears a revoked session the token stops — a snapshot
+  // here would live on in devCredentials and keep sending the dead token.
   return {
     apiUrl,
     ...(apiKey !== undefined ? { apiKey } : {}),
-    ...(oauthUsable ? { authToken } : {}),
     ...(projectId !== undefined ? { projectId } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };
@@ -96,8 +97,7 @@ if (sessionStorageAvailable()) {
     const handshaker = Handshaker();
     const getConfig = () => {
       const options = tolgee.getInitialOptions();
-      // Forward only the auth method resolveCredential actually selects, so the extension never has to re-decide
-      // precedence between a coexisting apiKey and authToken.
+      // Forward only the auth method resolveCredential selects, so the extension never re-decides precedence.
       const usingToken = Boolean(
         resolveCredential(options).authHeader.Authorization
       );

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -6,6 +6,7 @@ export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
 export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
 export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
 export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';
+export const PROJECT_ID_LOCAL_STORAGE = '__tolgee_projectId';
 
 function getCredentials() {
   const apiKey = sessionStorage.getItem(API_KEY_LOCAL_STORAGE) || undefined;
@@ -13,6 +14,8 @@ function getCredentials() {
   const branch = sessionStorage.getItem(BRANCH_LOCAL_STORAGE) || undefined;
   const authToken =
     sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE) || undefined;
+  const projectId =
+    sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
 
   // Either a static api key or an OAuth access token is enough to authenticate against the backend.
   if ((!apiKey && !authToken) || !apiUrl) {
@@ -23,6 +26,8 @@ function getCredentials() {
     apiKey,
     apiUrl,
     ...(authToken !== undefined ? { authToken } : {}),
+    // OAuth access tokens carry no embedded project (unlike a PAK), so the extension supplies the id explicitly.
+    ...(projectId !== undefined ? { projectId } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };
 }
@@ -32,6 +37,7 @@ function clearSessionStorage() {
   sessionStorage.removeItem(API_URL_LOCAL_STORAGE);
   sessionStorage.removeItem(BRANCH_LOCAL_STORAGE);
   sessionStorage.removeItem(AUTH_TOKEN_LOCAL_STORAGE);
+  sessionStorage.removeItem(PROJECT_ID_LOCAL_STORAGE);
 }
 
 function onDocumentReady(callback: () => void) {
@@ -81,6 +87,7 @@ if (sessionStorageAvailable()) {
           apiUrl: tolgee.getInitialOptions().apiUrl || '',
           apiKey: tolgee.getInitialOptions().apiKey || '',
           authToken: tolgee.getInitialOptions().authToken,
+          projectId: tolgee.getInitialOptions().projectId,
           branch: tolgee.getInitialOptions().branch,
         },
       }) as const;

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -19,16 +19,18 @@ function getCredentials() {
   const projectId =
     sessionStorage.getItem(PROJECT_ID_SESSION_STORAGE) || undefined;
 
+  // A bare OAuth token (no projectId) is unusable — withhold it so the fetch paths don't pick it over a working PAK.
   const oauthUsable = Boolean(authToken && projectId);
   if (!apiUrl || (!apiKey && !oauthUsable)) {
     return undefined;
   }
 
-  // The OAuth token is deliberately NOT forwarded here — a snapshot would live on in devCredentials and keep sending a
-  // revoked token after the extension clears the session (the token is read live per request instead).
+  // The token flows through the credentials so isDev()/the dev-backend gate see it (the request path still reads the
+  // live value from sessionStorage, so rotation is picked up and a disconnect's reload drops this snapshot).
   return {
     apiUrl,
     ...(apiKey !== undefined ? { apiKey } : {}),
+    ...(oauthUsable ? { authToken } : {}),
     ...(projectId !== undefined ? { projectId } : {}),
     ...(branch !== undefined ? { branch } : {}),
   };
@@ -96,7 +98,7 @@ if (sessionStorageAvailable()) {
     const handshaker = Handshaker();
     const getConfig = () => {
       const options = tolgee.getInitialOptions();
-      // Decide the winning auth method from the same snapshot we forward, so the flag and the forwarded value agree.
+      // Decide from the snapshot options we forward, not the live token, so the flag and the value can't disagree.
       const usingToken = Boolean(
         buildAuthHeader(options.authToken, options.apiKey).Authorization
       );

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -109,14 +109,17 @@ if (sessionStorageAvailable()) {
       };
     };
 
-    // Ask the same authority the fetch paths use, folding in the extension-injected projectId, so the advisory can't
-    // disagree with whether a request will actually require an explicit project.
+    // Ask the same authority the fetch paths use, folding in the extension-injected token and projectId, so the
+    // advisory can't disagree with whether a request will actually require an explicit project. Without the injected
+    // token, an OAuth session injected without a projectId (e.g. onto a PAK-configured page) would warn about nothing.
     const options = tolgee.getInitialOptions();
+    const injectedAuthToken =
+      sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE) || undefined;
     const injectedProjectId =
       sessionStorage.getItem(PROJECT_ID_LOCAL_STORAGE) || undefined;
     const { requiresExplicitProject, projectId } = resolveCredential({
       apiKey: options.apiKey,
-      authToken: options.authToken,
+      authToken: options.authToken ?? injectedAuthToken,
       projectId: options.projectId ?? injectedProjectId,
     });
     if (tolgee.isDev() && requiresExplicitProject && projectId === undefined) {

--- a/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/BrowserExtensionPlugin.ts
@@ -42,8 +42,6 @@ export function clearSessionStorage() {
   sessionStorage.removeItem(PROJECT_ID_SESSION_STORAGE);
 }
 
-// Warn on the SDK's own config: its DevBackend/client requests derive projectId only from init options, so an injected
-// projectId (which only the in-context UMD reads) must not silence a warning about a config that will still fail.
 function warnIfProjectIdMissing(tolgee: Parameters<TolgeePlugin>[0]) {
   if (!tolgee.isDev()) {
     return;

--- a/packages/web/src/package/BrowserExtensionPlugin/constants.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/constants.ts
@@ -1,3 +1,7 @@
 export const IN_CONTEXT_FILE = 'tolgee-in-context-tools.umd.min.js';
 export const IN_CONTEXT_UMD_NAME = '@tolgee/in-context-tools';
 export const IN_CONTEXT_EXPORT_NAME = 'InContextTools';
+
+// The extension injects the (rotating) OAuth access token here; the editor's client reads it live so a long-open page
+// always sends a current token. Shared so the read side (client) and the write side (extension plugin) can't drift.
+export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';

--- a/packages/web/src/package/BrowserExtensionPlugin/constants.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/constants.ts
@@ -1,3 +1,7 @@
 export const IN_CONTEXT_FILE = 'tolgee-in-context-tools.umd.min.js';
 export const IN_CONTEXT_UMD_NAME = '@tolgee/in-context-tools';
 export const IN_CONTEXT_EXPORT_NAME = 'InContextTools';
+
+// Window message the in-context editor posts to ask the browser extension to open its popup (so the user can re-connect
+// after their OAuth session expired). The extension's content script listens for it.
+export const OPEN_PLUGIN_MESSAGE = 'TOLGEE_OPEN_PLUGIN';

--- a/packages/web/src/package/BrowserExtensionPlugin/constants.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/constants.ts
@@ -2,6 +2,5 @@ export const IN_CONTEXT_FILE = 'tolgee-in-context-tools.umd.min.js';
 export const IN_CONTEXT_UMD_NAME = '@tolgee/in-context-tools';
 export const IN_CONTEXT_EXPORT_NAME = 'InContextTools';
 
-// Window message the in-context editor posts to ask the browser extension to open its popup (so the user can re-connect
-// after their OAuth session expired). The extension's content script listens for it.
+// Window message the in-context editor posts to ask the browser extension to open its popup; the extension listens.
 export const OPEN_PLUGIN_MESSAGE = 'TOLGEE_OPEN_PLUGIN';

--- a/packages/web/src/package/BrowserExtensionPlugin/constants.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/constants.ts
@@ -1,7 +1,3 @@
 export const IN_CONTEXT_FILE = 'tolgee-in-context-tools.umd.min.js';
 export const IN_CONTEXT_UMD_NAME = '@tolgee/in-context-tools';
 export const IN_CONTEXT_EXPORT_NAME = 'InContextTools';
-
-// The extension injects the (rotating) OAuth access token here; the editor's client reads it live so a long-open page
-// always sends a current token. Shared so the read side (client) and the write side (extension plugin) can't drift.
-export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';

--- a/packages/web/src/package/BrowserExtensionPlugin/loadInContextLib.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/loadInContextLib.ts
@@ -1,4 +1,5 @@
 import type { InContextTools } from '../InContextTools';
+import { isSSR } from '../tools/isSSR';
 import {
   IN_CONTEXT_FILE,
   IN_CONTEXT_UMD_NAME,
@@ -17,21 +18,53 @@ function injectScript(src: string) {
   });
 }
 
+type LocationLike = { origin: string; hostname: string; href: string };
+
+const isDevHost = (hostname: string) =>
+  hostname === 'localhost' ||
+  hostname === '127.0.0.1' ||
+  hostname === '::1' ||
+  hostname === '[::1]';
+
+// The injected UMD runs with the page's session/OAuth token, so a cross-origin override would be an arbitrary-script
+// load.
+export function isTrustedInContextUrl(
+  override: string | undefined,
+  location: LocationLike
+): boolean {
+  if (!override || !isDevHost(location.hostname)) {
+    return false;
+  }
+  try {
+    const url = new URL(override, location.href);
+    return url.origin === location.origin || isDevHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function overrideUrl(): string | undefined {
+  if (isSSR()) {
+    return undefined;
+  }
+  const override = (window as { __TOLGEE_IN_CONTEXT_URL__?: string })
+    .__TOLGEE_IN_CONTEXT_URL__;
+  return isTrustedInContextUrl(override, window.location)
+    ? override
+    : undefined;
+}
+
+export function inContextLibSrc(version: string): string {
+  return (
+    overrideUrl() || `${CDN_URL}/@tolgee/web@${version}/dist/${IN_CONTEXT_FILE}`
+  );
+}
+
 let injectPromise = null as any as Promise<typeof InContextTools>;
 
 export function loadInContextLib(version: string) {
   if (!injectPromise) {
-    // Dev override: load the in-context UMD from a local build instead of the CDN, so unpublished SDK changes (e.g. the
-    // OAuth Bearer support) can be exercised in-context. Set window.__TOLGEE_IN_CONTEXT_URL__ to a served
-    // tolgee-in-context-tools.umd.min.js before Tolgee initializes.
-    const override =
-      typeof window !== 'undefined'
-        ? (window as { __TOLGEE_IN_CONTEXT_URL__?: string })
-            .__TOLGEE_IN_CONTEXT_URL__
-        : undefined;
-    const src =
-      override || `${CDN_URL}/@tolgee/web@${version}/dist/${IN_CONTEXT_FILE}`;
-    injectPromise = injectScript(src).then(() => {
+    injectPromise = injectScript(inContextLibSrc(version)).then(() => {
       // @ts-ignore
       return window[IN_CONTEXT_UMD_NAME][IN_CONTEXT_EXPORT_NAME];
     });

--- a/packages/web/src/package/BrowserExtensionPlugin/loadInContextLib.ts
+++ b/packages/web/src/package/BrowserExtensionPlugin/loadInContextLib.ts
@@ -21,9 +21,17 @@ let injectPromise = null as any as Promise<typeof InContextTools>;
 
 export function loadInContextLib(version: string) {
   if (!injectPromise) {
-    injectPromise = injectScript(
-      `${CDN_URL}/@tolgee/web@${version}/dist/${IN_CONTEXT_FILE}`
-    ).then(() => {
+    // Dev override: load the in-context UMD from a local build instead of the CDN, so unpublished SDK changes (e.g. the
+    // OAuth Bearer support) can be exercised in-context. Set window.__TOLGEE_IN_CONTEXT_URL__ to a served
+    // tolgee-in-context-tools.umd.min.js before Tolgee initializes.
+    const override =
+      typeof window !== 'undefined'
+        ? (window as { __TOLGEE_IN_CONTEXT_URL__?: string })
+            .__TOLGEE_IN_CONTEXT_URL__
+        : undefined;
+    const src =
+      override || `${CDN_URL}/@tolgee/web@${version}/dist/${IN_CONTEXT_FILE}`;
+    injectPromise = injectScript(src).then(() => {
       // @ts-ignore
       return window[IN_CONTEXT_UMD_NAME][IN_CONTEXT_EXPORT_NAME];
     });

--- a/packages/web/src/package/DevBackend.ts
+++ b/packages/web/src/package/DevBackend.ts
@@ -7,6 +7,7 @@ function createDevBackend(): BackendDevMiddleware {
     getRecord({
       apiUrl,
       apiKey,
+      authToken,
       projectId,
       branch,
       language,
@@ -32,13 +33,19 @@ function createDevBackend(): BackendDevMiddleware {
         url.searchParams.append('filterTag', tag);
       });
 
-      if (getApiKeyType(apiKey) === 'tgpat' && projectId === undefined) {
-        throw new Error("You need to specify 'projectId' when using PAT key");
+      const needsExplicitProject =
+        authToken !== undefined || getApiKeyType(apiKey) === 'tgpat';
+      if (needsExplicitProject && projectId === undefined) {
+        throw new Error(
+          "You need to specify 'projectId' when using a PAT key or an OAuth token"
+        );
       }
 
       return fetch(url.toString(), {
         headers: {
-          'X-API-Key': apiKey || '',
+          ...(authToken
+            ? { Authorization: `Bearer ${authToken}` }
+            : { 'X-API-Key': apiKey || '' }),
           'Content-Type': 'application/json',
         },
         // @ts-ignore - tell next.js to not use cache

--- a/packages/web/src/package/DevBackend.ts
+++ b/packages/web/src/package/DevBackend.ts
@@ -1,6 +1,6 @@
-import { BackendDevMiddleware, sdkHeaders, TolgeePlugin } from '@tolgee/core';
+import { BackendDevMiddleware, TolgeePlugin } from '@tolgee/core';
 import { createUrl } from './tools/url';
-import { resolveCredential } from './tools/auth';
+import { bearerSdkHeaders, resolveCredential } from './tools/auth';
 
 function createDevBackend(): BackendDevMiddleware {
   return {
@@ -17,18 +17,21 @@ function createDevBackend(): BackendDevMiddleware {
     }) {
       const {
         authHeader,
-        projectId: pId,
+        projectId: resolvedProjectId,
         requiresExplicitProject,
       } = resolveCredential({ apiKey, authToken, projectId });
-      if (requiresExplicitProject && pId === undefined) {
+      if (requiresExplicitProject && resolvedProjectId === undefined) {
         throw new Error(
           "You need to specify 'projectId' when using a PAT key or an OAuth token"
         );
       }
 
       let url: URL;
-      if (pId !== undefined) {
-        url = createUrl(apiUrl, `/v2/projects/${pId}/translations/${language}`);
+      if (resolvedProjectId !== undefined) {
+        url = createUrl(
+          apiUrl,
+          `/v2/projects/${resolvedProjectId}/translations/${language}`
+        );
       } else {
         url = createUrl(apiUrl, `/v2/projects/translations/${language}`);
       }
@@ -45,8 +48,7 @@ function createDevBackend(): BackendDevMiddleware {
 
       return fetch(url.toString(), {
         headers: {
-          // Bearer requests are Tolgee-targeted here, so attach the sdk headers the shared fetch adds only for x-api-key.
-          ...(authHeader.Authorization ? sdkHeaders() : {}),
+          ...bearerSdkHeaders(authHeader),
           ...authHeader,
           'Content-Type': 'application/json',
         },

--- a/packages/web/src/package/DevBackend.ts
+++ b/packages/web/src/package/DevBackend.ts
@@ -1,4 +1,4 @@
-import { BackendDevMiddleware, TolgeePlugin } from '@tolgee/core';
+import { BackendDevMiddleware, sdkHeaders, TolgeePlugin } from '@tolgee/core';
 import { createUrl } from './tools/url';
 import { resolveCredential } from './tools/auth';
 
@@ -45,6 +45,8 @@ function createDevBackend(): BackendDevMiddleware {
 
       return fetch(url.toString(), {
         headers: {
+          // Bearer requests are Tolgee-targeted here, so attach the sdk headers the shared fetch adds only for x-api-key.
+          ...(authHeader.Authorization ? sdkHeaders() : {}),
           ...authHeader,
           'Content-Type': 'application/json',
         },

--- a/packages/web/src/package/DevBackend.ts
+++ b/packages/web/src/package/DevBackend.ts
@@ -1,6 +1,6 @@
 import { BackendDevMiddleware, TolgeePlugin } from '@tolgee/core';
-import { getApiKeyType, getProjectIdFromApiKey } from './tools/decodeApiKey';
 import { createUrl } from './tools/url';
+import { resolveCredential } from './tools/auth';
 
 function createDevBackend(): BackendDevMiddleware {
   return {
@@ -15,7 +15,17 @@ function createDevBackend(): BackendDevMiddleware {
       filterTag,
       fetch,
     }) {
-      const pId = getProjectIdFromApiKey(apiKey) ?? projectId;
+      const {
+        authHeader,
+        projectId: pId,
+        requiresExplicitProject,
+      } = resolveCredential({ apiKey, authToken, projectId });
+      if (requiresExplicitProject && pId === undefined) {
+        throw new Error(
+          "You need to specify 'projectId' when using a PAT key or an OAuth token"
+        );
+      }
+
       let url: URL;
       if (pId !== undefined) {
         url = createUrl(apiUrl, `/v2/projects/${pId}/translations/${language}`);
@@ -33,19 +43,9 @@ function createDevBackend(): BackendDevMiddleware {
         url.searchParams.append('filterTag', tag);
       });
 
-      const needsExplicitProject =
-        authToken !== undefined || getApiKeyType(apiKey) === 'tgpat';
-      if (needsExplicitProject && projectId === undefined) {
-        throw new Error(
-          "You need to specify 'projectId' when using a PAT key or an OAuth token"
-        );
-      }
-
       return fetch(url.toString(), {
         headers: {
-          ...(authToken
-            ? { Authorization: `Bearer ${authToken}` }
-            : { 'X-API-Key': apiKey || '' }),
+          ...authHeader,
           'Content-Type': 'application/json',
         },
         // @ts-ignore - tell next.js to not use cache

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -108,6 +108,19 @@ describe('resolveCredential', () => {
     expect(resolved.authHeader).toEqual({});
   });
 
+  it('treats an empty authToken as no credential (no unauthenticated request)', () => {
+    const resolved = resolveCredential({ authToken: '' });
+    expect(resolved.hasCredential).toBe(false);
+    expect(resolved.authHeader).toEqual({});
+    expect(resolved.requiresExplicitProject).toBe(false);
+  });
+
+  it('treats an empty apiKey as no credential', () => {
+    const resolved = resolveCredential({ apiKey: '' });
+    expect(resolved.hasCredential).toBe(false);
+    expect(resolved.authHeader).toEqual({});
+  });
+
   it('falls back to the supplied projectId for a malformed PAK (no NaN scope)', () => {
     // tgpak_mfrggzdf decodes to a non-numeric id, so the embedded project is unresolved.
     const resolved = resolveCredential({

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -3,7 +3,7 @@ import {
   resolveCredential,
   resolveLiveAuthToken,
 } from '../tools/auth';
-import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
+import { AUTH_TOKEN_SESSION_STORAGE } from '../tools/sessionStorageKeys';
 
 // A real tgpak whose base32 body decodes to project id 1 (see decodeApiKey.test.ts).
 const PAK_FOR_PROJECT_1 = 'tgpak_gfpxm4lin4zdazleoq4gm2rumfxgi2lfom2gw4dpguzxc';
@@ -15,7 +15,7 @@ describe('resolveLiveAuthToken', () => {
   });
 
   it('prefers the live sessionStorage token over the init token (rotation)', () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
     expect(resolveLiveAuthToken('init-token', undefined)).toBe('rotated');
   });
 
@@ -24,12 +24,12 @@ describe('resolveLiveAuthToken', () => {
   });
 
   it('reads sessionStorage on a fresh page when no init token was supplied', () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'injected');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'injected');
     expect(resolveLiveAuthToken(undefined, undefined)).toBe('injected');
   });
 
   it('never overrides a configured api key with a stray sessionStorage token', () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'stray');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'stray');
     // apiKey configured, no init token → stays on the api-key path
     expect(resolveLiveAuthToken(undefined, 'tgpak_x')).toBeUndefined();
   });
@@ -131,7 +131,7 @@ describe('resolveCredential', () => {
   });
 
   it('prefers a live sessionStorage token for the header and project requirement', () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
     const resolved = resolveCredential({ authToken: 'init', projectId: 3 });
     expect(resolved.authHeader).toEqual({ Authorization: 'Bearer rotated' });
     expect(resolved.requiresExplicitProject).toBe(true);

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -1,4 +1,5 @@
 import {
+  bearerSdkHeaders,
   buildAuthHeader,
   resolveCredential,
   resolveLiveAuthToken,
@@ -38,6 +39,15 @@ describe('resolveLiveAuthToken', () => {
     expect(resolveLiveAuthToken('', 'tgpak_x')).toBeUndefined();
   });
 
+  it('with both an init token and an api key, follows the token (guard does not fire)', () => {
+    expect(resolveLiveAuthToken('jwt', 'tgpak_x')).toBe('jwt');
+  });
+
+  it('a live token overrides even when an api key is also configured', () => {
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
+    expect(resolveLiveAuthToken('jwt', 'tgpak_x')).toBe('rotated');
+  });
+
   it('returns the fallback when sessionStorage access throws (SSR/sandboxed iframe)', () => {
     jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('blocked');
@@ -67,6 +77,19 @@ describe('buildAuthHeader', () => {
 
   it('returns no header when neither a token nor an api key is present', () => {
     expect(buildAuthHeader(undefined, undefined)).toEqual({});
+  });
+});
+
+describe('bearerSdkHeaders', () => {
+  it('adds the SDK type/version headers on a Bearer auth header', () => {
+    const headers = bearerSdkHeaders({ Authorization: 'Bearer x' });
+    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
+    expect(headers['x-tolgee-sdk-version']).toBeDefined();
+  });
+
+  it('adds nothing on an api-key auth header (the fetch wrapper adds them there)', () => {
+    expect(bearerSdkHeaders({ 'X-API-Key': 'x' })).toEqual({});
+    expect(bearerSdkHeaders({})).toEqual({});
   });
 });
 

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -1,0 +1,126 @@
+import {
+  buildAuthHeader,
+  resolveCredential,
+  resolveLiveAuthToken,
+} from '../tools/auth';
+import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
+
+// A real tgpak whose base32 body decodes to project id 1 (see decodeApiKey.test.ts).
+const PAK_FOR_PROJECT_1 = 'tgpak_gfpxm4lin4zdazleoq4gm2rumfxgi2lfom2gw4dpguzxc';
+
+describe('resolveLiveAuthToken', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('prefers the live sessionStorage token over the init token (rotation)', () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    expect(resolveLiveAuthToken('init-token', undefined)).toBe('rotated');
+  });
+
+  it('falls back to the init token when sessionStorage has none', () => {
+    expect(resolveLiveAuthToken('init-token', undefined)).toBe('init-token');
+  });
+
+  it('reads sessionStorage on a fresh page when no init token was supplied', () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'injected');
+    expect(resolveLiveAuthToken(undefined, undefined)).toBe('injected');
+  });
+
+  it('never overrides a configured api key with a stray sessionStorage token', () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'stray');
+    // apiKey configured, no init token → stays on the api-key path
+    expect(resolveLiveAuthToken(undefined, 'tgpak_x')).toBeUndefined();
+  });
+
+  it('returns the fallback when sessionStorage access throws (SSR/sandboxed iframe)', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(resolveLiveAuthToken('init-token', undefined)).toBe('init-token');
+  });
+});
+
+describe('buildAuthHeader', () => {
+  it('sends a Bearer header when a token is present', () => {
+    expect(buildAuthHeader('jwt', undefined)).toEqual({
+      Authorization: 'Bearer jwt',
+    });
+  });
+
+  it('sends X-API-Key when only an api key is present', () => {
+    expect(buildAuthHeader(undefined, 'tgpak_x')).toEqual({
+      'X-API-Key': 'tgpak_x',
+    });
+  });
+
+  it('prefers the token over the api key when both are present', () => {
+    expect(buildAuthHeader('jwt', 'tgpak_x')).toEqual({
+      Authorization: 'Bearer jwt',
+    });
+  });
+
+  it('returns no header when neither a token nor an api key is present', () => {
+    expect(buildAuthHeader(undefined, undefined)).toEqual({});
+  });
+});
+
+describe('resolveCredential', () => {
+  afterEach(() => sessionStorage.clear());
+
+  it('sends a Bearer header and requires an explicit project for an OAuth token', () => {
+    expect(resolveCredential({ authToken: 'jwt', projectId: 7 })).toEqual({
+      authHeader: { Authorization: 'Bearer jwt' },
+      hasCredential: true,
+      projectId: 7,
+      requiresExplicitProject: true,
+    });
+  });
+
+  it('requires an explicit project for a PAT (tgpat) key', () => {
+    expect(
+      resolveCredential({ apiKey: 'tgpat_x' }).requiresExplicitProject
+    ).toBe(true);
+  });
+
+  it('extracts the embedded project from a PAK and requires no explicit one', () => {
+    const resolved = resolveCredential({ apiKey: PAK_FOR_PROJECT_1 });
+    expect(resolved.projectId).toBe(1);
+    expect(resolved.requiresExplicitProject).toBe(false);
+    expect(resolved.authHeader).toEqual({ 'X-API-Key': PAK_FOR_PROJECT_1 });
+  });
+
+  it('scopes to the supplied projectId (not the PAK) when a token is also present', () => {
+    // Incoherent config, but the active credential is the token, so its request must not scope to the PAK's project.
+    const resolved = resolveCredential({
+      apiKey: PAK_FOR_PROJECT_1,
+      authToken: 'jwt',
+      projectId: 9,
+    });
+    expect(resolved.authHeader).toEqual({ Authorization: 'Bearer jwt' });
+    expect(resolved.projectId).toBe(9);
+  });
+
+  it('reports no credential and no header when neither is present', () => {
+    const resolved = resolveCredential({});
+    expect(resolved.hasCredential).toBe(false);
+    expect(resolved.authHeader).toEqual({});
+  });
+
+  it('falls back to the supplied projectId for a malformed PAK (no NaN scope)', () => {
+    // tgpak_mfrggzdf decodes to a non-numeric id, so the embedded project is unresolved.
+    const resolved = resolveCredential({
+      apiKey: 'tgpak_mfrggzdf',
+      projectId: 5,
+    });
+    expect(resolved.projectId).toBe(5);
+  });
+
+  it('prefers a live sessionStorage token for the header and project requirement', () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    const resolved = resolveCredential({ authToken: 'init', projectId: 3 });
+    expect(resolved.authHeader).toEqual({ Authorization: 'Bearer rotated' });
+    expect(resolved.requiresExplicitProject).toBe(true);
+  });
+});

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -34,6 +34,11 @@ describe('resolveLiveAuthToken', () => {
     expect(resolveLiveAuthToken(undefined, 'tgpak_x')).toBeUndefined();
   });
 
+  it('an empty-string init token does not disable the api-key hijack guard', () => {
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'stray');
+    expect(resolveLiveAuthToken('', 'tgpak_x')).toBeUndefined();
+  });
+
   it('returns the fallback when sessionStorage access throws (SSR/sandboxed iframe)', () => {
     jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('blocked');

--- a/packages/web/src/package/__test__/auth.test.ts
+++ b/packages/web/src/package/__test__/auth.test.ts
@@ -30,7 +30,6 @@ describe('resolveLiveAuthToken', () => {
 
   it('never overrides a configured api key with a stray sessionStorage token', () => {
     sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'stray');
-    // apiKey configured, no init token → stays on the api-key path
     expect(resolveLiveAuthToken(undefined, 'tgpak_x')).toBeUndefined();
   });
 

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -126,6 +126,17 @@ describe('compatibility with browser extension', () => {
     expect(loadInContextLib).not.toBeCalled();
   });
 
+  it('does not load in-context lib when apiUrl is missing', async () => {
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');
+
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+
+    expect(loadInContextLib).not.toBeCalled();
+  });
+
   it('forwards projectId injected into sessionStorage on the OAuth path', async () => {
     sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
     sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
@@ -237,7 +248,9 @@ describe('compatibility with browser extension', () => {
     warn.mockRestore();
   });
 
-  it('does not warn when the extension injected projectId into sessionStorage', () => {
+  it('still warns when only an injected projectId is present (SDK config lacks its own)', () => {
+    // The injected projectId is read by the in-context UMD, not by the SDK's own DevBackend/client requests, which
+    // derive it from init options — so a token-configured SDK with no projectId of its own must still be warned.
     sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');
     const warn = jest
       .spyOn(console, 'warn')
@@ -248,7 +261,7 @@ describe('compatibility with browser extension', () => {
       apiUrl: 'http://x',
     });
     tolgee.addPlugin(BrowserExtensionPlugin());
-    expect(warn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('projectId'));
     warn.mockRestore();
   });
 

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -128,8 +128,10 @@ describe('compatibility with browser extension', () => {
     const { credentials } = (inContextToolsFactory.mock.calls[0] as any)[0];
     expect(credentials.apiKey).toBeUndefined();
     expect(credentials.apiUrl).toEqual('test');
-    expect(credentials.authToken).toEqual('oauth-access-token');
     expect(credentials.projectId).toEqual('42');
+    // The token is not snapshotted into the credentials — it is read live from sessionStorage so a revoked session
+    // can't be kept alive by a stale copy.
+    expect(credentials.authToken).toBeUndefined();
   });
 
   it('does not load in-context lib for an OAuth token without a projectId', async () => {
@@ -182,7 +184,7 @@ describe('compatibility with browser extension', () => {
     expect(inContextToolsFactory).toBeCalledWith(
       expect.objectContaining({
         credentials: expect.objectContaining({
-          authToken: 'oauth-access-token',
+          apiUrl: 'test',
           projectId: '42',
         }),
       })
@@ -264,6 +266,22 @@ describe('compatibility with browser extension', () => {
       apiKey: 'tgpat_x',
       apiUrl: 'http://x',
       projectId: 5,
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not warn when not in dev mode, even if the credential would otherwise require a projectId', () => {
+    // authToken but no apiUrl → isDev() is false; resolveCredential would still flag requiresExplicitProject, so this
+    // isolates the isDev() early-return guard from the requiresExplicitProject check.
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      authToken: 'jwt',
+      apiUrl: '',
     });
     tolgee.addPlugin(BrowserExtensionPlugin());
     expect(warn).not.toHaveBeenCalled();

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -53,6 +53,23 @@ describe('compatibility with browser extension', () => {
     });
   });
 
+  it('forwards only the winning Bearer token when both apiKey and authToken are configured', async () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'test',
+      apiKey: 'tgpak_x',
+      authToken: 'jwt',
+      projectId: 5,
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+    expect(handshakerUpdate).toBeCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ apiKey: '', authToken: 'jwt' }),
+      })
+    );
+  });
+
   it('forwards authToken and projectId to the extension handshake', async () => {
     const tolgee = TolgeeCore().init({
       language: 'en',

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -165,6 +165,23 @@ describe('compatibility with browser extension', () => {
     warn.mockRestore();
   });
 
+  it('warns for an injected OAuth token without a projectId in dev mode', () => {
+    // A PAK page (dev mode) whose extension injects an OAuth token but no projectId: the injected token becomes the
+    // active credential, so in-context editing needs an explicit projectId — the advisory must fire.
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'injected-jwt');
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiKey: 'tgpak_gfpxm4lin4zdazleoq4gm2rumfxgi2lfom2gw4dpguzxc',
+      apiUrl: 'http://x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('projectId'));
+    warn.mockRestore();
+  });
+
   it('does not warn when a projectId is provided', () => {
     const warn = jest
       .spyOn(console, 'warn')

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -21,11 +21,11 @@ import { TolgeeCore } from '@tolgee/core';
 import { BrowserExtensionPlugin } from '../typedIndex';
 import { clearSessionStorage } from '../BrowserExtensionPlugin/BrowserExtensionPlugin';
 import {
-  API_KEY_LOCAL_STORAGE,
-  API_URL_LOCAL_STORAGE,
-  AUTH_TOKEN_LOCAL_STORAGE,
-  BRANCH_LOCAL_STORAGE,
-  PROJECT_ID_LOCAL_STORAGE,
+  API_KEY_SESSION_STORAGE,
+  API_URL_SESSION_STORAGE,
+  AUTH_TOKEN_SESSION_STORAGE,
+  BRANCH_SESSION_STORAGE,
+  PROJECT_ID_SESSION_STORAGE,
 } from '../tools/sessionStorageKeys';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
@@ -53,6 +53,22 @@ describe('compatibility with browser extension', () => {
     });
   });
 
+  it('forwards authToken and projectId to the extension handshake', async () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'test',
+      authToken: 'jwt',
+      projectId: 42,
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+    expect(handshakerUpdate).toBeCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ authToken: 'jwt', projectId: 42 }),
+      })
+    );
+  });
+
   it('sends branch from SDK config to extension', async () => {
     const tolgee = TolgeeCore().init({
       language: 'en',
@@ -72,8 +88,8 @@ describe('compatibility with browser extension', () => {
   });
 
   it('loads in-context lib if session storage is set', async () => {
-    sessionStorage.setItem(API_KEY_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
+    sessionStorage.setItem(API_KEY_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -83,9 +99,9 @@ describe('compatibility with browser extension', () => {
   });
 
   it('loads in-context lib with an OAuth token (no api key)', async () => {
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
-    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -100,8 +116,8 @@ describe('compatibility with browser extension', () => {
   });
 
   it('does not load in-context lib for an OAuth token without a projectId', async () => {
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -111,9 +127,9 @@ describe('compatibility with browser extension', () => {
   });
 
   it('forwards projectId injected into sessionStorage on the OAuth path', async () => {
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
-    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -131,9 +147,9 @@ describe('compatibility with browser extension', () => {
   });
 
   it('picks up branch from sessionStorage', async () => {
-    sessionStorage.setItem(API_KEY_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
-    sessionStorage.setItem(BRANCH_LOCAL_STORAGE, 'my-branch');
+    sessionStorage.setItem(API_KEY_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(BRANCH_SESSION_STORAGE, 'my-branch');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -165,16 +181,30 @@ describe('compatibility with browser extension', () => {
     warn.mockRestore();
   });
 
-  it('warns for an injected OAuth token without a projectId in dev mode', () => {
-    // A PAK page (dev mode) whose extension injects an OAuth token but no projectId: the injected token becomes the
-    // active credential, so in-context editing needs an explicit projectId — the advisory must fire.
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'injected-jwt');
+  it('does not warn on a working PAK page even if a stray OAuth token was injected', () => {
+    // The tgpak embeds its project and the hijack guard keeps the stray injected token from taking over, so in-context
+    // editing works via the PAK — the advisory must not fire on it.
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'injected-jwt');
     const warn = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined);
     const tolgee = TolgeeCore().init({
       language: 'en',
       apiKey: 'tgpak_gfpxm4lin4zdazleoq4gm2rumfxgi2lfom2gw4dpguzxc',
+      apiUrl: 'http://x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns for a token-configured SDK missing its projectId in dev mode', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      authToken: 'jwt',
       apiUrl: 'http://x',
     });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -208,7 +238,7 @@ describe('compatibility with browser extension', () => {
   });
 
   it('does not warn when the extension injected projectId into sessionStorage', () => {
-    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
+    sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');
     const warn = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined);
@@ -237,18 +267,18 @@ describe('compatibility with browser extension', () => {
   });
 
   it('clearSessionStorage removes every injected key', () => {
-    sessionStorage.setItem(API_KEY_LOCAL_STORAGE, 'a');
-    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'b');
-    sessionStorage.setItem(BRANCH_LOCAL_STORAGE, 'c');
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'd');
-    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, 'e');
+    sessionStorage.setItem(API_KEY_SESSION_STORAGE, 'a');
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'b');
+    sessionStorage.setItem(BRANCH_SESSION_STORAGE, 'c');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'd');
+    sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, 'e');
     clearSessionStorage();
     [
-      API_KEY_LOCAL_STORAGE,
-      API_URL_LOCAL_STORAGE,
-      BRANCH_LOCAL_STORAGE,
-      AUTH_TOKEN_LOCAL_STORAGE,
-      PROJECT_ID_LOCAL_STORAGE,
+      API_KEY_SESSION_STORAGE,
+      API_URL_SESSION_STORAGE,
+      BRANCH_SESSION_STORAGE,
+      AUTH_TOKEN_SESSION_STORAGE,
+      PROJECT_ID_SESSION_STORAGE,
     ].forEach((key) => expect(sessionStorage.getItem(key)).toBeNull());
   });
 

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -163,9 +163,8 @@ describe('compatibility with browser extension', () => {
     expect(credentials.apiKey).toBeUndefined();
     expect(credentials.apiUrl).toEqual('test');
     expect(credentials.projectId).toEqual('42');
-    // The token is not snapshotted into the credentials — it is read live from sessionStorage so a revoked session
-    // can't be kept alive by a stale copy.
-    expect(credentials.authToken).toBeUndefined();
+    // The token flows through the credentials so isDev()/the dev-backend gate recognise the token-only session.
+    expect(credentials.authToken).toEqual('oauth-access-token');
   });
 
   it('does not load in-context lib for an OAuth token without a projectId', async () => {
@@ -218,7 +217,7 @@ describe('compatibility with browser extension', () => {
     expect(inContextToolsFactory).toBeCalledWith(
       expect.objectContaining({
         credentials: expect.objectContaining({
-          apiUrl: 'test',
+          authToken: 'oauth-access-token',
           projectId: '42',
         }),
       })

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -126,6 +126,21 @@ describe('compatibility with browser extension', () => {
     expect(loadInContextLib).not.toBeCalled();
   });
 
+  it('withholds a bare OAuth token (no projectId) when a PAK is also present', async () => {
+    sessionStorage.setItem(API_URL_SESSION_STORAGE, 'test');
+    sessionStorage.setItem(API_KEY_SESSION_STORAGE, 'tgpak_x');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'bare-token');
+
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+
+    expect(loadInContextLib).toBeCalledTimes(1);
+    const { credentials } = (inContextToolsFactory.mock.calls[0] as any)[0];
+    expect(credentials.apiKey).toEqual('tgpak_x');
+    expect(credentials.authToken).toBeUndefined();
+  });
+
   it('does not load in-context lib when apiUrl is missing', async () => {
     sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'oauth-access-token');
     sessionStorage.setItem(PROJECT_ID_SESSION_STORAGE, '42');

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -85,6 +85,7 @@ describe('compatibility with browser extension', () => {
   it('loads in-context lib with an OAuth token (no api key)', async () => {
     sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
     sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
 
     const tolgee = TolgeeCore().init({ language: 'en' });
     tolgee.addPlugin(BrowserExtensionPlugin());
@@ -95,6 +96,18 @@ describe('compatibility with browser extension', () => {
     expect(credentials.apiKey).toBeUndefined();
     expect(credentials.apiUrl).toEqual('test');
     expect(credentials.authToken).toEqual('oauth-access-token');
+    expect(credentials.projectId).toEqual('42');
+  });
+
+  it('does not load in-context lib for an OAuth token without a projectId', async () => {
+    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
+
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+
+    expect(loadInContextLib).not.toBeCalled();
   });
 
   it('forwards projectId injected into sessionStorage on the OAuth path', async () => {

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -386,7 +386,7 @@ describe('compatibility with browser extension', () => {
     expect(
       fileContent.toString().includes(`"${IN_CONTEXT_UMD_NAME}"`)
     ).toBeTruthy();
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+
     const module = await import(`../../../dist/${IN_CONTEXT_FILE}`);
     expect(typeof module[IN_CONTEXT_EXPORT_NAME]).toEqual('function');
   });

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -70,6 +70,40 @@ describe('compatibility with browser extension', () => {
     );
   });
 
+  it('forwards the api key (no token) unchanged in the handshake', async () => {
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'test',
+      apiKey: 'tgpak_x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+    expect(handshakerUpdate).toBeCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          apiKey: 'tgpak_x',
+          authToken: undefined,
+        }),
+      })
+    );
+  });
+
+  it('still forwards the api key when a stray sessionStorage token is present', async () => {
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'stray');
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiUrl: 'test',
+      apiKey: 'tgpak_x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+    expect(handshakerUpdate).toBeCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ apiKey: 'tgpak_x' }),
+      })
+    );
+  });
+
   it('forwards authToken and projectId to the extension handshake', async () => {
     const tolgee = TolgeeCore().init({
       language: 'en',

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -19,12 +19,14 @@ jest.mock('../BrowserExtensionPlugin/loadInContextLib', () => ({
 
 import { TolgeeCore } from '@tolgee/core';
 import { BrowserExtensionPlugin } from '../typedIndex';
+import { clearSessionStorage } from '../BrowserExtensionPlugin/BrowserExtensionPlugin';
 import {
   API_KEY_LOCAL_STORAGE,
   API_URL_LOCAL_STORAGE,
   AUTH_TOKEN_LOCAL_STORAGE,
   BRANCH_LOCAL_STORAGE,
-} from '../BrowserExtensionPlugin/BrowserExtensionPlugin';
+  PROJECT_ID_LOCAL_STORAGE,
+} from '../tools/sessionStorageKeys';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 
@@ -89,11 +91,27 @@ describe('compatibility with browser extension', () => {
     await tolgee.run();
 
     expect(loadInContextLib).toBeCalledTimes(1);
+    const { credentials } = (inContextToolsFactory.mock.calls[0] as any)[0];
+    expect(credentials.apiKey).toBeUndefined();
+    expect(credentials.apiUrl).toEqual('test');
+    expect(credentials.authToken).toEqual('oauth-access-token');
+  });
+
+  it('forwards projectId injected into sessionStorage on the OAuth path', async () => {
+    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
+    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
+
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+
+    expect(loadInContextLib).toBeCalledTimes(1);
     expect(inContextToolsFactory).toBeCalledWith(
       expect.objectContaining({
         credentials: expect.objectContaining({
-          apiUrl: 'test',
           authToken: 'oauth-access-token',
+          projectId: '42',
         }),
       })
     );
@@ -118,6 +136,90 @@ describe('compatibility with browser extension', () => {
         },
       })
     );
+  });
+
+  it('warns about a missing projectId in dev mode', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiKey: 'tgpat_x',
+      apiUrl: 'http://x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('projectId'));
+    warn.mockRestore();
+  });
+
+  it('does not warn when a projectId is provided', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiKey: 'tgpat_x',
+      apiUrl: 'http://x',
+      projectId: 5,
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not warn in production (no dev credentials)', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not warn when the extension injected projectId into sessionStorage', () => {
+    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, '42');
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      authToken: 'jwt',
+      apiUrl: 'http://x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not warn when the projectId is embedded in a PAK api key', () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const tolgee = TolgeeCore().init({
+      language: 'en',
+      apiKey: 'tgpak_gfpxm4lin4zdazleoq4gm2rumfxgi2lfom2gw4dpguzxc',
+      apiUrl: 'http://x',
+    });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('clearSessionStorage removes every injected key', () => {
+    sessionStorage.setItem(API_KEY_LOCAL_STORAGE, 'a');
+    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'b');
+    sessionStorage.setItem(BRANCH_LOCAL_STORAGE, 'c');
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'd');
+    sessionStorage.setItem(PROJECT_ID_LOCAL_STORAGE, 'e');
+    clearSessionStorage();
+    [
+      API_KEY_LOCAL_STORAGE,
+      API_URL_LOCAL_STORAGE,
+      BRANCH_LOCAL_STORAGE,
+      AUTH_TOKEN_LOCAL_STORAGE,
+      PROJECT_ID_LOCAL_STORAGE,
+    ].forEach((key) => expect(sessionStorage.getItem(key)).toBeNull());
   });
 
   it('builded module is valid', async () => {

--- a/packages/web/src/package/__test__/browser.extension.test.ts
+++ b/packages/web/src/package/__test__/browser.extension.test.ts
@@ -22,6 +22,7 @@ import { BrowserExtensionPlugin } from '../typedIndex';
 import {
   API_KEY_LOCAL_STORAGE,
   API_URL_LOCAL_STORAGE,
+  AUTH_TOKEN_LOCAL_STORAGE,
   BRANCH_LOCAL_STORAGE,
 } from '../BrowserExtensionPlugin/BrowserExtensionPlugin';
 import { readFile } from 'fs/promises';
@@ -77,6 +78,25 @@ describe('compatibility with browser extension', () => {
     await tolgee.run();
 
     expect(loadInContextLib).toBeCalledTimes(1);
+  });
+
+  it('loads in-context lib with an OAuth token (no api key)', async () => {
+    sessionStorage.setItem(API_URL_LOCAL_STORAGE, 'test');
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'oauth-access-token');
+
+    const tolgee = TolgeeCore().init({ language: 'en' });
+    tolgee.addPlugin(BrowserExtensionPlugin());
+    await tolgee.run();
+
+    expect(loadInContextLib).toBeCalledTimes(1);
+    expect(inContextToolsFactory).toBeCalledWith(
+      expect.objectContaining({
+        credentials: expect.objectContaining({
+          apiUrl: 'test',
+          authToken: 'oauth-access-token',
+        }),
+      })
+    );
   });
 
   it('picks up branch from sessionStorage', async () => {

--- a/packages/web/src/package/__test__/client.test.ts
+++ b/packages/web/src/package/__test__/client.test.ts
@@ -87,6 +87,14 @@ describe('in-context client auth (customFetch)', () => {
     expect(headers['authorization']).toBeUndefined();
   });
 
+  it('attaches SDK type/version headers on a Bearer request', async () => {
+    const fetchMock = mockFetch();
+    await call({ authToken: 'jwt' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
+    expect(headers['x-tolgee-sdk-version']).toBeDefined();
+  });
+
   it('prefers a live sessionStorage token over the init token', async () => {
     sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
     const fetchMock = mockFetch();

--- a/packages/web/src/package/__test__/client.test.ts
+++ b/packages/web/src/package/__test__/client.test.ts
@@ -1,0 +1,110 @@
+import { client } from '../ui/client/client';
+import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
+
+describe('in-context client auth (customFetch)', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    sessionStorage.clear();
+  });
+
+  const mockFetch = () => {
+    const fn = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve('{}'),
+        headers: { get: () => null },
+      } as unknown as Response)
+    );
+    global.fetch = fn as any;
+    return fn;
+  };
+
+  const call = (options: Record<string, unknown>) =>
+    client(
+      '/v2/projects/{projectId}/keys' as any,
+      'get' as any,
+      {} as any,
+      {
+        apiUrl: 'http://localhost',
+        projectId: 1,
+        ...options,
+      } as any
+    );
+
+  const lowerCasedHeadersOf = (fetchMock: any) =>
+    fetchMock.mock.calls[0][1].headers as Record<string, string>;
+
+  it('sends Authorization: Bearer for an OAuth token', async () => {
+    const fetchMock = mockFetch();
+    await call({ authToken: 'jwt' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['authorization']).toEqual('Bearer jwt');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('sends X-API-Key for an api key', async () => {
+    const fetchMock = mockFetch();
+    await call({ apiKey: 'tgpak_x' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['x-api-key']).toEqual('tgpak_x');
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('prefers a live sessionStorage token over the init token', async () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    const fetchMock = mockFetch();
+    await call({ authToken: 'init-token' });
+    expect(lowerCasedHeadersOf(fetchMock)['authorization']).toEqual(
+      'Bearer rotated'
+    );
+  });
+
+  it('does not let a stray sessionStorage token hijack a configured api key', async () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'stray');
+    const fetchMock = mockFetch();
+    await call({ apiKey: 'tgpak_x' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['x-api-key']).toEqual('tgpak_x');
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('throws when neither an api key nor a token is available', async () => {
+    mockFetch();
+    await expect(call({})).rejects.toThrow('api_key_not_specified');
+  });
+
+  it('throws project_id_not_specified for an OAuth request to a project endpoint with no projectId', async () => {
+    mockFetch();
+    await expect(
+      call({ authToken: 'jwt', projectId: undefined })
+    ).rejects.toThrow('project_id_not_specified');
+  });
+
+  it('allows an OAuth request to a non-project endpoint without a projectId', async () => {
+    const fetchMock = mockFetch();
+    await client(
+      '/v2/image-upload' as any,
+      'post' as any,
+      {} as any,
+      {
+        apiUrl: 'http://localhost',
+        authToken: 'jwt',
+      } as any
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lowerCasedHeadersOf(fetchMock)['authorization']).toEqual(
+      'Bearer jwt'
+    );
+  });
+
+  it('enforces the projectId precondition off the live token, not just the init options', async () => {
+    // No init credential, but a token sits in sessionStorage — the guard must still fire (it keys off the live token).
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'live');
+    mockFetch();
+    await expect(call({ projectId: undefined })).rejects.toThrow(
+      'project_id_not_specified'
+    );
+  });
+});

--- a/packages/web/src/package/__test__/client.test.ts
+++ b/packages/web/src/package/__test__/client.test.ts
@@ -48,13 +48,35 @@ describe('in-context client auth (customFetch)', () => {
     const fetchMock = mockFetch();
     // Real project endpoints omit the project segment (they assume a PAK); a Bearer token carries none, so the client
     // must inject the explicit projectId into the path.
-    await client('/v2/projects/keys' as any, 'get' as any, {} as any, {
-      apiUrl: 'http://localhost',
-      authToken: 'jwt',
-      projectId: 7,
-    } as any);
+    await client(
+      '/v2/projects/keys' as any,
+      'get' as any,
+      {} as any,
+      {
+        apiUrl: 'http://localhost',
+        authToken: 'jwt',
+        projectId: 7,
+      } as any
+    );
     const url = (fetchMock.mock.calls[0] as unknown as [string])[0];
     expect(url).toContain('/v2/projects/7/keys');
+  });
+
+  it('scopes a PAT request to its explicit projectId and sends X-API-Key', async () => {
+    const fetchMock = mockFetch();
+    await client(
+      '/v2/projects/keys' as any,
+      'get' as any,
+      {} as any,
+      {
+        apiUrl: 'http://localhost',
+        apiKey: 'tgpat_x',
+        projectId: 9,
+      } as any
+    );
+    const url = (fetchMock.mock.calls[0] as unknown as [string])[0];
+    expect(url).toContain('/v2/projects/9/keys');
+    expect(lowerCasedHeadersOf(fetchMock)['x-api-key']).toEqual('tgpat_x');
   });
 
   it('sends X-API-Key for an api key', async () => {

--- a/packages/web/src/package/__test__/client.test.ts
+++ b/packages/web/src/package/__test__/client.test.ts
@@ -1,5 +1,5 @@
 import { client } from '../ui/client/client';
-import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
+import { AUTH_TOKEN_SESSION_STORAGE } from '../tools/sessionStorageKeys';
 
 describe('in-context client auth (customFetch)', () => {
   const realFetch = global.fetch;
@@ -44,6 +44,19 @@ describe('in-context client auth (customFetch)', () => {
     expect(headers['x-api-key']).toBeUndefined();
   });
 
+  it('scopes the Bearer request URL to the supplied projectId', async () => {
+    const fetchMock = mockFetch();
+    // Real project endpoints omit the project segment (they assume a PAK); a Bearer token carries none, so the client
+    // must inject the explicit projectId into the path.
+    await client('/v2/projects/keys' as any, 'get' as any, {} as any, {
+      apiUrl: 'http://localhost',
+      authToken: 'jwt',
+      projectId: 7,
+    } as any);
+    const url = (fetchMock.mock.calls[0] as unknown as [string])[0];
+    expect(url).toContain('/v2/projects/7/keys');
+  });
+
   it('sends X-API-Key for an api key', async () => {
     const fetchMock = mockFetch();
     await call({ apiKey: 'tgpak_x' });
@@ -53,7 +66,7 @@ describe('in-context client auth (customFetch)', () => {
   });
 
   it('prefers a live sessionStorage token over the init token', async () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
     const fetchMock = mockFetch();
     await call({ authToken: 'init-token' });
     expect(lowerCasedHeadersOf(fetchMock)['authorization']).toEqual(
@@ -62,7 +75,7 @@ describe('in-context client auth (customFetch)', () => {
   });
 
   it('does not let a stray sessionStorage token hijack a configured api key', async () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'stray');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'stray');
     const fetchMock = mockFetch();
     await call({ apiKey: 'tgpak_x' });
     const headers = lowerCasedHeadersOf(fetchMock);
@@ -101,7 +114,7 @@ describe('in-context client auth (customFetch)', () => {
 
   it('enforces the projectId precondition off the live token, not just the init options', async () => {
     // No init credential, but a token sits in sessionStorage — the guard must still fire (it keys off the live token).
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'live');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'live');
     mockFetch();
     await expect(call({ projectId: undefined })).rejects.toThrow(
       'project_id_not_specified'

--- a/packages/web/src/package/__test__/errorAlert.test.tsx
+++ b/packages/web/src/package/__test__/errorAlert.test.tsx
@@ -45,7 +45,7 @@ describe('ErrorAlert getErrorContent — OAuth recovery', () => {
     });
     expect(spy).toHaveBeenCalledWith(
       { type: OPEN_PLUGIN_MESSAGE },
-      expect.anything()
+      window.origin
     );
     spy.mockRestore();
     act(() => root.unmount());

--- a/packages/web/src/package/__test__/errorAlert.test.tsx
+++ b/packages/web/src/package/__test__/errorAlert.test.tsx
@@ -1,0 +1,59 @@
+import { createRoot, Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { getErrorContent } from '../ui/KeyDialog/ErrorAlert';
+import { HttpError, ErrorStatusCode } from '../ui/client/HttpError';
+import { OPEN_PLUGIN_MESSAGE } from '../BrowserExtensionPlugin/constants';
+
+const renderFor = (code: string) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(
+      getErrorContent(new HttpError(code as ErrorStatusCode), 'http://x') as any
+    );
+  });
+  return { container, root };
+};
+
+describe('ErrorAlert getErrorContent — OAuth recovery', () => {
+  const jwtCodes = [
+    'unauthenticated',
+    'invalid_jwt_token',
+    'expired_jwt_token',
+    'general_jwt_error',
+  ];
+
+  it.each(jwtCodes)('renders the sign-in-again recovery for %s', (code) => {
+    const { container, root } = renderFor(code);
+    expect(container.textContent).toContain("You're not signed in");
+    expect(container.querySelector('button')?.textContent).toContain(
+      'Open the Tolgee plugin'
+    );
+    act(() => root.unmount());
+  });
+
+  it('the recovery button posts the open-plugin message', () => {
+    const spy = jest
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => undefined);
+    const { container, root } = renderFor('expired_jwt_token');
+    act(() => {
+      container
+        .querySelector('button')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(spy).toHaveBeenCalledWith(
+      { type: OPEN_PLUGIN_MESSAGE },
+      expect.anything()
+    );
+    spy.mockRestore();
+    act(() => root.unmount());
+  });
+
+  it('renders the missing-projectId guidance', () => {
+    const { container, root } = renderFor('project_id_not_specified');
+    expect(container.textContent).toContain('project id');
+    act(() => root.unmount());
+  });
+});

--- a/packages/web/src/package/__test__/fetch.apiUrl.test.ts
+++ b/packages/web/src/package/__test__/fetch.apiUrl.test.ts
@@ -1,6 +1,7 @@
 import { TolgeeCore } from '@tolgee/core';
 import { createFetchingUtility } from './fetchingUtillity';
 import { DevBackend } from '../DevBackend';
+import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
 
 describe('can handle relative urls in apiUrl', () => {
   let f: ReturnType<typeof createFetchingUtility>;
@@ -67,5 +68,104 @@ describe('can handle relative urls in apiUrl', () => {
     const url = new URL(args[0]);
     expect(url.searchParams.get('branch')).toEqual('feature/test');
     expect(url.searchParams.get('ns')).toEqual('home');
+  });
+});
+
+describe('dev backend authentication headers', () => {
+  let f: ReturnType<typeof createFetchingUtility>;
+
+  beforeEach(() => {
+    f = createFetchingUtility();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  const lowerCasedHeadersOf = (fetchMock: any) =>
+    fetchMock.mock.calls[0][1].headers as Record<string, string>;
+
+  it('sends X-API-Key and no Authorization for an api key', async () => {
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({
+        language: 'en',
+        availableLanguages: ['en'],
+        fetch: fetchMock,
+        apiUrl: '/test',
+        apiKey: 'test',
+      });
+    await tolgee.loadRecord({ language: 'en' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['x-api-key']).toEqual('test');
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('sends a Bearer token and no X-API-Key for an OAuth token', async () => {
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({
+        language: 'en',
+        availableLanguages: ['en'],
+        fetch: fetchMock,
+        apiUrl: '/test',
+        authToken: 'jwt',
+        projectId: 1,
+      });
+    await tolgee.loadRecord({ language: 'en' });
+    const headers = lowerCasedHeadersOf(fetchMock);
+    expect(headers['authorization']).toEqual('Bearer jwt');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('does not fetch when an OAuth token is used without a projectId', async () => {
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({
+        language: 'en',
+        availableLanguages: ['en'],
+        fetch: fetchMock,
+        apiUrl: '/test',
+        authToken: 'jwt',
+      });
+    await tolgee.loadRecord({ language: 'en' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when a PAT (tgpat) key is used without a projectId', async () => {
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({
+        language: 'en',
+        availableLanguages: ['en'],
+        fetch: fetchMock,
+        apiUrl: '/test',
+        apiKey: 'tgpat_x',
+      });
+    await tolgee.loadRecord({ language: 'en' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers a live rotated sessionStorage token over the init token', async () => {
+    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({
+        language: 'en',
+        availableLanguages: ['en'],
+        fetch: fetchMock,
+        apiUrl: '/test',
+        authToken: 'init-token',
+        projectId: 1,
+      });
+    await tolgee.loadRecord({ language: 'en' });
+    expect(lowerCasedHeadersOf(fetchMock)['authorization']).toEqual(
+      'Bearer rotated'
+    );
   });
 });

--- a/packages/web/src/package/__test__/fetch.apiUrl.test.ts
+++ b/packages/web/src/package/__test__/fetch.apiUrl.test.ts
@@ -132,8 +132,11 @@ describe('dev backend authentication headers', () => {
         apiUrl: '/test',
         authToken: 'jwt',
       });
+    const errorHandler = jest.fn();
+    tolgee.on('error', errorHandler);
     await tolgee.loadRecord({ language: 'en' });
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalled();
   });
 
   it('does not fetch when a PAT (tgpat) key is used without a projectId', async () => {
@@ -147,8 +150,11 @@ describe('dev backend authentication headers', () => {
         apiUrl: '/test',
         apiKey: 'tgpat_x',
       });
+    const errorHandler = jest.fn();
+    tolgee.on('error', errorHandler);
     await tolgee.loadRecord({ language: 'en' });
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalled();
   });
 
   it('prefers a live rotated sessionStorage token over the init token', async () => {

--- a/packages/web/src/package/__test__/fetch.apiUrl.test.ts
+++ b/packages/web/src/package/__test__/fetch.apiUrl.test.ts
@@ -1,7 +1,7 @@
 import { TolgeeCore } from '@tolgee/core';
 import { createFetchingUtility } from './fetchingUtillity';
 import { DevBackend } from '../DevBackend';
-import { AUTH_TOKEN_LOCAL_STORAGE } from '../tools/sessionStorageKeys';
+import { AUTH_TOKEN_SESSION_STORAGE } from '../tools/sessionStorageKeys';
 
 describe('can handle relative urls in apiUrl', () => {
   let f: ReturnType<typeof createFetchingUtility>;
@@ -151,7 +151,7 @@ describe('dev backend authentication headers', () => {
   });
 
   it('prefers a live rotated sessionStorage token over the init token', async () => {
-    sessionStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE, 'rotated');
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'rotated');
     const fetchMock = f.fetchWithResponse({});
     const tolgee = TolgeeCore()
       .use(DevBackend())

--- a/packages/web/src/package/__test__/fetch.apiUrl.test.ts
+++ b/packages/web/src/package/__test__/fetch.apiUrl.test.ts
@@ -118,6 +118,7 @@ describe('dev backend authentication headers', () => {
     const headers = lowerCasedHeadersOf(fetchMock);
     expect(headers['authorization']).toEqual('Bearer jwt');
     expect(headers['x-api-key']).toBeUndefined();
+    expect(headers['x-tolgee-sdk-type']).toEqual('JS');
   });
 
   it('does not fetch when an OAuth token is used without a projectId', async () => {

--- a/packages/web/src/package/__test__/fetch.apiUrl.test.ts
+++ b/packages/web/src/package/__test__/fetch.apiUrl.test.ts
@@ -29,6 +29,28 @@ describe('can handle relative urls in apiUrl', () => {
     );
   });
 
+  it('a token-only injected credential activates dev mode and fires the dev backend', async () => {
+    // The extension injects an OAuth token via overrideCredentials + sessionStorage with no init credential; isDev() and
+    // the dev-backend gate must see it, or the page silently stays on production translations.
+    const fetchMock = f.fetchWithResponse({});
+    const tolgee = TolgeeCore()
+      .use(DevBackend())
+      .init({ language: 'en', availableLanguages: ['en'], fetch: fetchMock });
+
+    expect(tolgee.isDev()).toBe(false);
+    sessionStorage.setItem(AUTH_TOKEN_SESSION_STORAGE, 'jwt');
+    tolgee.overrideCredentials({
+      apiUrl: '/test',
+      authToken: 'jwt',
+      projectId: 1,
+    });
+
+    expect(tolgee.isDev()).toBe(true);
+    await tolgee.loadRecord({ language: 'en' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    sessionStorage.clear();
+  });
+
   it('dev backend can resolve apiUrl with included path', async () => {
     const fetchMock = f.fetchWithResponse({});
     const tolgee = TolgeeCore()

--- a/packages/web/src/package/__test__/loadInContextLib.test.ts
+++ b/packages/web/src/package/__test__/loadInContextLib.test.ts
@@ -32,6 +32,19 @@ describe('isTrustedInContextUrl', () => {
     );
   });
 
+  it('treats an IPv6 loopback host as a dev page', () => {
+    const v6Page = {
+      origin: 'http://[::1]:5173',
+      hostname: '[::1]',
+      href: 'http://[::1]:5173/',
+    };
+    expect(isTrustedInContextUrl('/tolgee.umd.js', v6Page)).toBe(true);
+    expect(isTrustedInContextUrl('http://[::1]:9000/x.js', v6Page)).toBe(true);
+    expect(isTrustedInContextUrl('/x.js', { ...v6Page, hostname: '::1' })).toBe(
+      true
+    );
+  });
+
   it('rejects a cross-origin override even on a dev page', () => {
     expect(
       isTrustedInContextUrl('https://evil.example.com/x.js', devPage)

--- a/packages/web/src/package/__test__/loadInContextLib.test.ts
+++ b/packages/web/src/package/__test__/loadInContextLib.test.ts
@@ -53,6 +53,18 @@ describe('isTrustedInContextUrl', () => {
     ).toBe(false);
   });
 
+  it('rejects a protocol-relative override to another host', () => {
+    expect(isTrustedInContextUrl('//evil.example.com/x.js', devPage)).toBe(
+      false
+    );
+  });
+
+  it('rejects a userinfo override that embeds a dev host before an evil host', () => {
+    expect(
+      isTrustedInContextUrl('https://localhost@evil.example.com/x.js', devPage)
+    ).toBe(false);
+  });
+
   it('rejects every override on a production page (including same-origin)', () => {
     expect(
       isTrustedInContextUrl('https://app.example.com/x.js', prodPage)

--- a/packages/web/src/package/__test__/loadInContextLib.test.ts
+++ b/packages/web/src/package/__test__/loadInContextLib.test.ts
@@ -1,3 +1,5 @@
+jest.mock('../tools/isSSR', () => ({ isSSR: jest.fn(() => false) }));
+import { isSSR } from '../tools/isSSR';
 import {
   inContextLibSrc,
   isTrustedInContextUrl,
@@ -90,6 +92,14 @@ describe('overrideUrl', () => {
   it('returns undefined when the global is unset', () => {
     expect(overrideUrl()).toBeUndefined();
   });
+
+  it('returns undefined under SSR without touching window', () => {
+    (isSSR as jest.Mock).mockReturnValueOnce(true);
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = '/tolgee.umd.js';
+    expect(overrideUrl()).toBeUndefined();
+  });
 });
 
 describe('inContextLibSrc', () => {
@@ -111,5 +121,13 @@ describe('inContextLibSrc', () => {
     ).__TOLGEE_IN_CONTEXT_URL__ = 'https://evil.example.com/x.js';
     expect(inContextLibSrc('1.2.3')).toContain('cdn.jsdelivr.net');
     expect(inContextLibSrc('1.2.3')).toContain('@tolgee/web@1.2.3');
+  });
+
+  it('falls back to the CDN under SSR (ignoring any override)', () => {
+    (isSSR as jest.Mock).mockReturnValueOnce(true);
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = '/local.umd.js';
+    expect(inContextLibSrc('1.2.3')).toContain('cdn.jsdelivr.net');
   });
 });

--- a/packages/web/src/package/__test__/loadInContextLib.test.ts
+++ b/packages/web/src/package/__test__/loadInContextLib.test.ts
@@ -1,0 +1,102 @@
+import {
+  inContextLibSrc,
+  isTrustedInContextUrl,
+  overrideUrl,
+} from '../BrowserExtensionPlugin/loadInContextLib';
+
+const devPage = {
+  origin: 'http://localhost:5173',
+  hostname: 'localhost',
+  href: 'http://localhost:5173/',
+};
+const prodPage = {
+  origin: 'https://app.example.com',
+  hostname: 'app.example.com',
+  href: 'https://app.example.com/app',
+};
+
+describe('isTrustedInContextUrl', () => {
+  it('honors a same-origin override on a dev page', () => {
+    expect(isTrustedInContextUrl('/tolgee.umd.js', devPage)).toBe(true);
+    expect(
+      isTrustedInContextUrl('http://localhost:5173/tolgee.umd.js', devPage)
+    ).toBe(true);
+  });
+
+  it('honors a localhost override on a dev page', () => {
+    expect(isTrustedInContextUrl('http://localhost:9000/x.js', devPage)).toBe(
+      true
+    );
+    expect(isTrustedInContextUrl('http://127.0.0.1:9000/x.js', devPage)).toBe(
+      true
+    );
+  });
+
+  it('rejects a cross-origin override even on a dev page', () => {
+    expect(
+      isTrustedInContextUrl('https://evil.example.com/x.js', devPage)
+    ).toBe(false);
+  });
+
+  it('rejects every override on a production page (including same-origin)', () => {
+    expect(
+      isTrustedInContextUrl('https://app.example.com/x.js', prodPage)
+    ).toBe(false);
+    expect(isTrustedInContextUrl('http://localhost:9000/x.js', prodPage)).toBe(
+      false
+    );
+  });
+
+  it('rejects a missing or malformed override', () => {
+    expect(isTrustedInContextUrl(undefined, devPage)).toBe(false);
+    expect(isTrustedInContextUrl('http://[malformed', devPage)).toBe(false);
+  });
+});
+
+describe('overrideUrl', () => {
+  // jsdom serves the tests from http://localhost, i.e. a dev origin.
+  afterEach(() => {
+    delete (window as { __TOLGEE_IN_CONTEXT_URL__?: string })
+      .__TOLGEE_IN_CONTEXT_URL__;
+  });
+
+  it('returns a trusted same-origin override', () => {
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = '/tolgee.umd.js';
+    expect(overrideUrl()).toEqual('/tolgee.umd.js');
+  });
+
+  it('discards a cross-origin override', () => {
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = 'https://evil.example.com/x.js';
+    expect(overrideUrl()).toBeUndefined();
+  });
+
+  it('returns undefined when the global is unset', () => {
+    expect(overrideUrl()).toBeUndefined();
+  });
+});
+
+describe('inContextLibSrc', () => {
+  afterEach(() => {
+    delete (window as { __TOLGEE_IN_CONTEXT_URL__?: string })
+      .__TOLGEE_IN_CONTEXT_URL__;
+  });
+
+  it('uses a trusted override as the script source', () => {
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = '/local.umd.js';
+    expect(inContextLibSrc('1.2.3')).toEqual('/local.umd.js');
+  });
+
+  it('falls back to the CDN when there is no trusted override', () => {
+    (
+      window as { __TOLGEE_IN_CONTEXT_URL__?: string }
+    ).__TOLGEE_IN_CONTEXT_URL__ = 'https://evil.example.com/x.js';
+    expect(inContextLibSrc('1.2.3')).toContain('cdn.jsdelivr.net');
+    expect(inContextLibSrc('1.2.3')).toContain('@tolgee/web@1.2.3');
+  });
+});

--- a/packages/web/src/package/__test__/queryProvider.test.tsx
+++ b/packages/web/src/package/__test__/queryProvider.test.tsx
@@ -1,0 +1,33 @@
+import { useContext } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import {
+  GlobalOptions,
+  QueryContext,
+  QueryProvider,
+} from '../ui/client/QueryProvider';
+
+describe('QueryProvider auth wiring', () => {
+  it('threads authToken from props into the QueryContext the client reads', () => {
+    let captured: GlobalOptions | undefined;
+    const Consumer = () => {
+      captured = useContext(QueryContext);
+      return null;
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <QueryProvider apiUrl="http://x" projectId={1} authToken="jwt">
+          <Consumer />
+        </QueryProvider>
+      );
+    });
+
+    expect(captured?.authToken).toEqual('jwt');
+    expect(captured?.apiUrl).toEqual('http://x');
+    act(() => root.unmount());
+  });
+});

--- a/packages/web/src/package/entry-development.ts
+++ b/packages/web/src/package/entry-development.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 export * from './entry-production';
 import { InContextTools } from './InContextTools';
 

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -28,12 +28,12 @@ export function resolveCredential(credentials: Credentials): {
 }
 
 export function resolveLiveAuthToken(
-  fallback: string | undefined,
+  initAuthToken: string | undefined,
   apiKey: string | undefined
 ): string | undefined {
   // An api-key-configured SDK must not be hijacked by a stray sessionStorage token: only follow the live token when a
-  // token (fallback) is the intended auth path.
-  if (!fallback && apiKey) {
+  // token is the intended auth path.
+  if (!initAuthToken && apiKey) {
     return undefined;
   }
   try {
@@ -46,7 +46,7 @@ export function resolveLiveAuthToken(
   } catch {
     // sessionStorage can throw (SSR, sandboxed iframes).
   }
-  return fallback;
+  return initAuthToken;
 }
 
 export function buildAuthHeader(
@@ -62,8 +62,7 @@ export function buildAuthHeader(
   return {};
 }
 
-// The shared core fetch attaches the SDK headers only for x-api-key (so it never tags BackendFetch's third-party-CDN
-// path); these Tolgee-targeted Bearer request builders re-add them.
+// createFetchFunction adds the sdk headers only for x-api-key; these Tolgee-targeted Bearer builders re-add them.
 export function bearerSdkHeaders(
   authHeader: Record<string, string>
 ): Record<string, string> {

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -1,5 +1,5 @@
 import { getApiKeyType, getProjectIdFromApiKey } from './decodeApiKey';
-import { AUTH_TOKEN_LOCAL_STORAGE } from './sessionStorageKeys';
+import { AUTH_TOKEN_SESSION_STORAGE } from './sessionStorageKeys';
 
 export function resolveLiveAuthToken(
   fallback: string | undefined,
@@ -12,7 +12,7 @@ export function resolveLiveAuthToken(
   }
   try {
     if (typeof sessionStorage !== 'undefined') {
-      const injected = sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE);
+      const injected = sessionStorage.getItem(AUTH_TOKEN_SESSION_STORAGE);
       if (injected) {
         return injected;
       }
@@ -50,11 +50,8 @@ export function resolveCredential(credentials: Credentials): {
 } {
   const { apiKey, authToken, projectId } = credentials;
   const token = resolveLiveAuthToken(authToken, apiKey);
-  // Treat an empty string as no credential: buildAuthHeader emits no header for it, so keying off `!== undefined` would
-  // report hasCredential (and dispatch an unauthenticated request) and skip embedded-project resolution for `''`.
   const hasToken = Boolean(token);
   const hasApiKey = Boolean(apiKey);
-  // embedded project applies only when the PAK itself is the active credential
   const embedded = !hasToken ? getProjectIdFromApiKey(apiKey) : undefined;
   return {
     authHeader: buildAuthHeader(token, apiKey),

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -1,0 +1,63 @@
+import { getApiKeyType, getProjectIdFromApiKey } from './decodeApiKey';
+import { AUTH_TOKEN_LOCAL_STORAGE } from './sessionStorageKeys';
+
+export function resolveLiveAuthToken(
+  fallback: string | undefined,
+  apiKey: string | undefined
+): string | undefined {
+  // An api-key-configured SDK must not be hijacked by a stray sessionStorage token: only follow the live token when a
+  // token (fallback) is the intended auth path.
+  if (fallback === undefined && apiKey !== undefined) {
+    return undefined;
+  }
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      const injected = sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE);
+      if (injected) {
+        return injected;
+      }
+    }
+  } catch {
+    // sessionStorage can throw (SSR, sandboxed iframes).
+  }
+  return fallback;
+}
+
+export function buildAuthHeader(
+  authToken: string | undefined,
+  apiKey: string | undefined
+): Record<string, string> {
+  if (authToken) {
+    return { Authorization: `Bearer ${authToken}` };
+  }
+  if (apiKey) {
+    return { 'X-API-Key': apiKey };
+  }
+  return {};
+}
+
+type Credentials = {
+  apiKey?: string;
+  authToken?: string;
+  projectId?: number | string;
+};
+
+export function resolveCredential(credentials: Credentials): {
+  authHeader: Record<string, string>;
+  hasCredential: boolean;
+  projectId: number | string | undefined;
+  requiresExplicitProject: boolean;
+} {
+  const { apiKey, authToken, projectId } = credentials;
+  const token = resolveLiveAuthToken(authToken, apiKey);
+  // embedded project applies only when the PAK itself is the active credential
+  const embedded =
+    token === undefined ? getProjectIdFromApiKey(apiKey) : undefined;
+  return {
+    authHeader: buildAuthHeader(token, apiKey),
+    hasCredential: token !== undefined || apiKey !== undefined,
+    projectId: embedded ?? projectId,
+    requiresExplicitProject:
+      token !== undefined || getApiKeyType(apiKey) === 'tgpat',
+  };
+}

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -1,13 +1,38 @@
 import { getApiKeyType, getProjectIdFromApiKey } from './decodeApiKey';
 import { AUTH_TOKEN_SESSION_STORAGE } from './sessionStorageKeys';
 
+type Credentials = {
+  apiKey?: string;
+  authToken?: string;
+  projectId?: number | string;
+};
+
+export function resolveCredential(credentials: Credentials): {
+  authHeader: Record<string, string>;
+  hasCredential: boolean;
+  projectId: number | string | undefined;
+  requiresExplicitProject: boolean;
+} {
+  const { apiKey, authToken, projectId } = credentials;
+  const token = resolveLiveAuthToken(authToken, apiKey);
+  const hasToken = Boolean(token);
+  const hasApiKey = Boolean(apiKey);
+  const embedded = !hasToken ? getProjectIdFromApiKey(apiKey) : undefined;
+  return {
+    authHeader: buildAuthHeader(token, apiKey),
+    hasCredential: hasToken || hasApiKey,
+    projectId: embedded ?? projectId,
+    requiresExplicitProject: hasToken || getApiKeyType(apiKey) === 'tgpat',
+  };
+}
+
 export function resolveLiveAuthToken(
   fallback: string | undefined,
   apiKey: string | undefined
 ): string | undefined {
   // An api-key-configured SDK must not be hijacked by a stray sessionStorage token: only follow the live token when a
-  // token (fallback) is the intended auth path.
-  if (fallback === undefined && apiKey !== undefined) {
+  // token (fallback) is the intended auth path. Boolean checks so an empty-string token doesn't slip past the guard.
+  if (!fallback && apiKey) {
     return undefined;
   }
   try {
@@ -34,29 +59,4 @@ export function buildAuthHeader(
     return { 'X-API-Key': apiKey };
   }
   return {};
-}
-
-type Credentials = {
-  apiKey?: string;
-  authToken?: string;
-  projectId?: number | string;
-};
-
-export function resolveCredential(credentials: Credentials): {
-  authHeader: Record<string, string>;
-  hasCredential: boolean;
-  projectId: number | string | undefined;
-  requiresExplicitProject: boolean;
-} {
-  const { apiKey, authToken, projectId } = credentials;
-  const token = resolveLiveAuthToken(authToken, apiKey);
-  const hasToken = Boolean(token);
-  const hasApiKey = Boolean(apiKey);
-  const embedded = !hasToken ? getProjectIdFromApiKey(apiKey) : undefined;
-  return {
-    authHeader: buildAuthHeader(token, apiKey),
-    hasCredential: hasToken || hasApiKey,
-    projectId: embedded ?? projectId,
-    requiresExplicitProject: hasToken || getApiKeyType(apiKey) === 'tgpat',
-  };
 }

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -50,14 +50,16 @@ export function resolveCredential(credentials: Credentials): {
 } {
   const { apiKey, authToken, projectId } = credentials;
   const token = resolveLiveAuthToken(authToken, apiKey);
+  // Treat an empty string as no credential: buildAuthHeader emits no header for it, so keying off `!== undefined` would
+  // report hasCredential (and dispatch an unauthenticated request) and skip embedded-project resolution for `''`.
+  const hasToken = Boolean(token);
+  const hasApiKey = Boolean(apiKey);
   // embedded project applies only when the PAK itself is the active credential
-  const embedded =
-    token === undefined ? getProjectIdFromApiKey(apiKey) : undefined;
+  const embedded = !hasToken ? getProjectIdFromApiKey(apiKey) : undefined;
   return {
     authHeader: buildAuthHeader(token, apiKey),
-    hasCredential: token !== undefined || apiKey !== undefined,
+    hasCredential: hasToken || hasApiKey,
     projectId: embedded ?? projectId,
-    requiresExplicitProject:
-      token !== undefined || getApiKeyType(apiKey) === 'tgpat',
+    requiresExplicitProject: hasToken || getApiKeyType(apiKey) === 'tgpat',
   };
 }

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -1,3 +1,4 @@
+import { sdkHeaders } from '@tolgee/core';
 import { getApiKeyType, getProjectIdFromApiKey } from './decodeApiKey';
 import { AUTH_TOKEN_SESSION_STORAGE } from './sessionStorageKeys';
 
@@ -31,7 +32,7 @@ export function resolveLiveAuthToken(
   apiKey: string | undefined
 ): string | undefined {
   // An api-key-configured SDK must not be hijacked by a stray sessionStorage token: only follow the live token when a
-  // token (fallback) is the intended auth path. Boolean checks so an empty-string token doesn't slip past the guard.
+  // token (fallback) is the intended auth path.
   if (!fallback && apiKey) {
     return undefined;
   }
@@ -59,4 +60,12 @@ export function buildAuthHeader(
     return { 'X-API-Key': apiKey };
   }
   return {};
+}
+
+// The shared core fetch attaches the SDK headers only for x-api-key (so it never tags BackendFetch's third-party-CDN
+// path); these Tolgee-targeted Bearer request builders re-add them.
+export function bearerSdkHeaders(
+  authHeader: Record<string, string>
+): Record<string, string> {
+  return authHeader.Authorization ? sdkHeaders() : {};
 }

--- a/packages/web/src/package/tools/auth.ts
+++ b/packages/web/src/package/tools/auth.ts
@@ -62,7 +62,6 @@ export function buildAuthHeader(
   return {};
 }
 
-// createFetchFunction adds the sdk headers only for x-api-key; these Tolgee-targeted Bearer builders re-add them.
 export function bearerSdkHeaders(
   authHeader: Record<string, string>
 ): Record<string, string> {

--- a/packages/web/src/package/tools/decodeApiKey.test.ts
+++ b/packages/web/src/package/tools/decodeApiKey.test.ts
@@ -11,4 +11,9 @@ describe('get projectId from api key', () => {
   it("won't fail on legacy code", () => {
     expect(getProjectIdFromApiKey(OLD_KEY)).toBeUndefined();
   });
+
+  it('returns undefined for a tgpak whose body decodes to a non-numeric id', () => {
+    // tgpak_mfrggzdf base32-decodes to "abcde" -> Number(...) is NaN
+    expect(getProjectIdFromApiKey('tgpak_mfrggzdf')).toBeUndefined();
+  });
 });

--- a/packages/web/src/package/tools/decodeApiKey.ts
+++ b/packages/web/src/package/tools/decodeApiKey.ts
@@ -64,7 +64,8 @@ export function getProjectIdFromApiKey(
     const [prefix, rest] = key.split('_');
     if (prefix === 'tgpak') {
       const [projectId] = base32Decode(rest).split('_');
-      return Number(projectId);
+      const parsed = Number(projectId);
+      return Number.isNaN(parsed) ? undefined : parsed;
     }
   } catch {
     // eslint-disable-next-line no-console

--- a/packages/web/src/package/tools/extension.ts
+++ b/packages/web/src/package/tools/extension.ts
@@ -102,6 +102,7 @@ export type LibConfig = {
   config: {
     apiUrl: string;
     apiKey: string;
+    authToken?: string;
     branch?: string;
   };
 };

--- a/packages/web/src/package/tools/extension.ts
+++ b/packages/web/src/package/tools/extension.ts
@@ -103,6 +103,7 @@ export type LibConfig = {
     apiUrl: string;
     apiKey: string;
     authToken?: string;
+    projectId?: number | string;
     branch?: string;
   };
 };

--- a/packages/web/src/package/tools/sessionStorageKeys.ts
+++ b/packages/web/src/package/tools/sessionStorageKeys.ts
@@ -1,6 +1,6 @@
-// sessionStorage keys the browser extension writes and the SDK reads (the `_LOCAL_STORAGE` suffix is historical).
-export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
-export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
-export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
-export const PROJECT_ID_LOCAL_STORAGE = '__tolgee_projectId';
-export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';
+// sessionStorage keys the browser extension writes and the SDK reads.
+export const API_KEY_SESSION_STORAGE = '__tolgee_apiKey';
+export const API_URL_SESSION_STORAGE = '__tolgee_apiUrl';
+export const BRANCH_SESSION_STORAGE = '__tolgee_branch';
+export const PROJECT_ID_SESSION_STORAGE = '__tolgee_projectId';
+export const AUTH_TOKEN_SESSION_STORAGE = '__tolgee_authToken';

--- a/packages/web/src/package/tools/sessionStorageKeys.ts
+++ b/packages/web/src/package/tools/sessionStorageKeys.ts
@@ -1,0 +1,6 @@
+// sessionStorage keys the browser extension writes and the SDK reads (the `_LOCAL_STORAGE` suffix is historical).
+export const API_KEY_LOCAL_STORAGE = '__tolgee_apiKey';
+export const API_URL_LOCAL_STORAGE = '__tolgee_apiUrl';
+export const BRANCH_LOCAL_STORAGE = '__tolgee_branch';
+export const PROJECT_ID_LOCAL_STORAGE = '__tolgee_projectId';
+export const AUTH_TOKEN_LOCAL_STORAGE = '__tolgee_authToken';

--- a/packages/web/src/package/tools/sessionStorageKeys.ts
+++ b/packages/web/src/package/tools/sessionStorageKeys.ts
@@ -1,4 +1,3 @@
-// sessionStorage keys the browser extension writes and the SDK reads.
 export const API_KEY_SESSION_STORAGE = '__tolgee_apiKey';
 export const API_URL_SESSION_STORAGE = '__tolgee_apiUrl';
 export const BRANCH_SESSION_STORAGE = '__tolgee_branch';

--- a/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
+++ b/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
@@ -53,7 +53,10 @@ function DocsAPIKeys() {
   );
 }
 
-function getErrorContent({ code, params, message }: HttpError, apiUrl: string) {
+export function getErrorContent(
+  { code, params, message }: HttpError,
+  apiUrl: string
+) {
   switch (code) {
     case 'operation_not_permitted':
       return (

--- a/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
+++ b/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
@@ -74,8 +74,17 @@ function getErrorContent({ code, params, message }: HttpError, apiUrl: string) {
     case 'api_key_not_specified':
       return (
         <>
-          <AlertTitle>Oops... I miss the API key</AlertTitle>
+          <AlertTitle>Oops... I miss the API key or access token</AlertTitle>
           Add it in the code or via the chrome plugin. <DocsInContext />
+        </>
+      );
+
+    case 'project_id_not_specified':
+      return (
+        <>
+          <AlertTitle>Oops... I miss the project id</AlertTitle>
+          An OAuth token or PAT carries no project, so projectId must be set in
+          the Tolgee configuration. <DocsInContext />
         </>
       );
 

--- a/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
+++ b/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
@@ -118,6 +118,16 @@ export function getErrorContent(
         </>
       );
 
+    case 'project_not_found':
+      return (
+        <>
+          <AlertTitle>Project not found</AlertTitle>
+          The configured project doesn't exist on this server, or your account
+          can't access it. Check the projectId in the Tolgee configuration, or
+          ask for access. <DocsInContext />
+        </>
+      );
+
     case 'permissions_not_sufficient_to_edit':
       return (
         <>

--- a/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
+++ b/packages/web/src/package/ui/KeyDialog/ErrorAlert.tsx
@@ -1,8 +1,9 @@
-import { Alert, AlertTitle } from '@mui/material';
+import { Alert, AlertTitle, Link } from '@mui/material';
 import { HttpError } from '../client/HttpError';
 import { useDialogContext } from './dialogContext';
 import { NewTabLink } from './Link';
 import { createUrl } from '../../tools/url';
+import { OPEN_PLUGIN_MESSAGE } from '../../BrowserExtensionPlugin/constants';
 
 type Props = {
   error: HttpError | Error;
@@ -29,6 +30,21 @@ function DocsInContext() {
   );
 }
 
+function OpenExtension() {
+  return (
+    <Link
+      component="button"
+      type="button"
+      sx={{ verticalAlign: 'baseline' }}
+      onClick={() =>
+        window.postMessage({ type: OPEN_PLUGIN_MESSAGE }, window.origin)
+      }
+    >
+      Open the Tolgee plugin
+    </Link>
+  );
+}
+
 function DocsAPIKeys() {
   return (
     <NewTabLink href="https://tolgee.io/platform/account_settings/api_keys_and_pat_tokens">
@@ -52,6 +68,17 @@ function getErrorContent({ code, params, message }: HttpError, apiUrl: string) {
         <>
           <AlertTitle>Invalid API key</AlertTitle>
           Check it in the code or in the chrome plugin. <DocsInContext />
+        </>
+      );
+
+    case 'unauthenticated':
+    case 'invalid_jwt_token':
+    case 'expired_jwt_token':
+    case 'general_jwt_error':
+      return (
+        <>
+          <AlertTitle>You're not signed in</AlertTitle>
+          Sign in again in the Tolgee plugin to keep editing. <OpenExtension />
         </>
       );
 

--- a/packages/web/src/package/ui/KeyDialog/KeyDialog.tsx
+++ b/packages/web/src/package/ui/KeyDialog/KeyDialog.tsx
@@ -33,6 +33,7 @@ export const KeyDialog = ({ uiProps, keyData }: Props) => {
     <QueryProvider
       apiUrl={uiProps.apiUrl}
       apiKey={uiProps.apiKey}
+      authToken={uiProps.authToken}
       projectId={uiProps.projectId}
       branch={uiProps.branch}
     >

--- a/packages/web/src/package/ui/client/HttpError.ts
+++ b/packages/web/src/package/ui/client/HttpError.ts
@@ -7,6 +7,7 @@ type ErrorCustomStatus =
   | 'fetch_error'
   | 'api_url_not_specified'
   | 'api_key_not_specified'
+  | 'project_id_not_specified'
   | 'api_url_not_valid'
   | 'permissions_not_sufficient_to_edit';
 

--- a/packages/web/src/package/ui/client/QueryProvider.tsx
+++ b/packages/web/src/package/ui/client/QueryProvider.tsx
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 import { QueryClientProvider, QueryClient } from 'react-query';
 
 export type GlobalOptions = {
-  apiKey: string;
+  apiKey?: string;
   apiUrl: string;
   projectId: string | number | undefined;
   branch?: string;

--- a/packages/web/src/package/ui/client/QueryProvider.tsx
+++ b/packages/web/src/package/ui/client/QueryProvider.tsx
@@ -6,6 +6,7 @@ export type GlobalOptions = {
   apiUrl: string;
   projectId: string | number | undefined;
   branch?: string;
+  authToken?: string;
 };
 
 const queryClient = new QueryClient({
@@ -28,9 +29,12 @@ export const QueryProvider = ({
   apiKey,
   projectId,
   branch,
+  authToken,
 }: React.PropsWithChildren<Props>) => {
   return (
-    <QueryContext.Provider value={{ apiUrl, apiKey, projectId, branch }}>
+    <QueryContext.Provider
+      value={{ apiUrl, apiKey, projectId, branch, authToken }}
+    >
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </QueryContext.Provider>
   );

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -74,7 +74,7 @@ async function customFetch(
   if (!isUrlValid(options.apiUrl)) {
     throw new HttpError('api_url_not_valid');
   }
-  if (options.apiKey === undefined) {
+  if (options.apiKey === undefined && options.authToken === undefined) {
     throw new HttpError('api_key_not_specified');
   }
 
@@ -82,7 +82,9 @@ async function customFetch(
   init.headers = init.headers || {};
   init.headers = {
     ...init.headers,
-    'X-API-Key': options.apiKey,
+    ...(options.authToken
+      ? { Authorization: `Bearer ${options.authToken}` }
+      : { 'X-API-Key': options.apiKey! }),
   };
 
   const url = createUrl(options.apiUrl, input.toString()).toString();

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -1,28 +1,11 @@
 import { createFetchFunction } from '@tolgee/core';
-import { getProjectIdFromApiKey } from '../../tools/decodeApiKey';
 import { paths } from './apiSchema.generated';
 import { GlobalOptions } from './QueryProvider';
 import { RequestParamsType, ResponseContent } from './types';
 import { HttpError } from './HttpError';
 import { isUrlValid } from '../tools/validateUrl';
 import { createUrl } from '../../tools/url';
-import { AUTH_TOKEN_LOCAL_STORAGE } from '../../BrowserExtensionPlugin/constants';
-
-// The browser extension keeps a rotating OAuth access token in sessionStorage; prefer that live value over the one
-// captured at init, so a page left open past the token's lifetime still authenticates each new in-context request.
-function resolveAuthToken(fallback: string | undefined): string | undefined {
-  try {
-    if (typeof sessionStorage !== 'undefined') {
-      const injected = sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE);
-      if (injected) {
-        return injected;
-      }
-    }
-  } catch {
-    // sessionStorage can throw (SSR, sandboxed iframes) — fall back to the token passed at init.
-  }
-  return fallback;
-}
+import { resolveCredential } from '../../tools/auth';
 
 const errorFromResponse = (status: number, body: any) => {
   if (body?.code) {
@@ -83,6 +66,7 @@ function buildQuery(object: { [key: string]: any }): string {
 async function customFetch(
   input: RequestInfo,
   options: GlobalOptions,
+  credential: ReturnType<typeof resolveCredential>,
   init?: RequestInit
 ) {
   if (options.apiUrl === undefined) {
@@ -91,18 +75,15 @@ async function customFetch(
   if (!isUrlValid(options.apiUrl)) {
     throw new HttpError('api_url_not_valid');
   }
-  if (options.apiKey === undefined && options.authToken === undefined) {
+  if (!credential.hasCredential) {
     throw new HttpError('api_key_not_specified');
   }
 
-  const authToken = resolveAuthToken(options.authToken);
   init = init || {};
   init.headers = init.headers || {};
   init.headers = {
     ...init.headers,
-    ...(authToken
-      ? { Authorization: `Bearer ${authToken}` }
-      : { 'X-API-Key': options.apiKey! }),
+    ...credential.authHeader,
   };
 
   const url = createUrl(options.apiUrl, input.toString()).toString();
@@ -138,9 +119,16 @@ export async function client<
   const pathParams = (request as any)?.path || {};
   let urlResult = url as string;
 
-  const projectId = getProjectIdFromApiKey(options.apiKey) || options.projectId;
-  if (projectId !== undefined) {
-    pathParams.projectId = projectId;
+  const credential = resolveCredential(options);
+  if (
+    credential.requiresExplicitProject &&
+    credential.projectId === undefined &&
+    urlResult.includes('/projects/')
+  ) {
+    throw new HttpError('project_id_not_specified');
+  }
+  if (credential.projectId !== undefined) {
+    pathParams.projectId = credential.projectId;
     urlResult = addProjectIdToUrl(urlResult);
   }
 
@@ -182,7 +170,7 @@ export async function client<
     queryString = '?' + query;
   }
 
-  return customFetch(urlResult + queryString, options, {
+  return customFetch(urlResult + queryString, options, credential, {
     method: method as string,
     body: body || jsonBody,
     headers: jsonBody

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -1,4 +1,4 @@
-import { createFetchFunction } from '@tolgee/core';
+import { createFetchFunction, sdkHeaders } from '@tolgee/core';
 import { paths } from './apiSchema.generated';
 import { GlobalOptions } from './QueryProvider';
 import { RequestParamsType, ResponseContent } from './types';
@@ -82,6 +82,8 @@ async function customFetch(
   init = init || {};
   init.headers = init.headers || {};
   init.headers = {
+    // Bearer requests are Tolgee-targeted here, so attach the sdk headers the shared fetch adds only for x-api-key.
+    ...(credential.authHeader.Authorization ? sdkHeaders() : {}),
     ...init.headers,
     ...credential.authHeader,
   };

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -6,6 +6,23 @@ import { RequestParamsType, ResponseContent } from './types';
 import { HttpError } from './HttpError';
 import { isUrlValid } from '../tools/validateUrl';
 import { createUrl } from '../../tools/url';
+import { AUTH_TOKEN_LOCAL_STORAGE } from '../../BrowserExtensionPlugin/constants';
+
+// The browser extension keeps a rotating OAuth access token in sessionStorage; prefer that live value over the one
+// captured at init, so a page left open past the token's lifetime still authenticates each new in-context request.
+function resolveAuthToken(fallback: string | undefined): string | undefined {
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      const injected = sessionStorage.getItem(AUTH_TOKEN_LOCAL_STORAGE);
+      if (injected) {
+        return injected;
+      }
+    }
+  } catch {
+    // sessionStorage can throw (SSR, sandboxed iframes) — fall back to the token passed at init.
+  }
+  return fallback;
+}
 
 const errorFromResponse = (status: number, body: any) => {
   if (body?.code) {
@@ -78,12 +95,13 @@ async function customFetch(
     throw new HttpError('api_key_not_specified');
   }
 
+  const authToken = resolveAuthToken(options.authToken);
   init = init || {};
   init.headers = init.headers || {};
   init.headers = {
     ...init.headers,
-    ...(options.authToken
-      ? { Authorization: `Bearer ${options.authToken}` }
+    ...(authToken
+      ? { Authorization: `Bearer ${authToken}` }
       : { 'X-API-Key': options.apiKey! }),
   };
 

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -1,11 +1,11 @@
-import { createFetchFunction, sdkHeaders } from '@tolgee/core';
+import { createFetchFunction } from '@tolgee/core';
 import { paths } from './apiSchema.generated';
 import { GlobalOptions } from './QueryProvider';
 import { RequestParamsType, ResponseContent } from './types';
 import { HttpError } from './HttpError';
 import { isUrlValid } from '../tools/validateUrl';
 import { createUrl } from '../../tools/url';
-import { resolveCredential } from '../../tools/auth';
+import { bearerSdkHeaders, resolveCredential } from '../../tools/auth';
 
 const errorFromResponse = (status: number, body: any) => {
   if (body?.code) {
@@ -82,8 +82,7 @@ async function customFetch(
   init = init || {};
   init.headers = init.headers || {};
   init.headers = {
-    // Bearer requests are Tolgee-targeted here, so attach the sdk headers the shared fetch adds only for x-api-key.
-    ...(credential.authHeader.Authorization ? sdkHeaders() : {}),
+    ...bearerSdkHeaders(credential.authHeader),
     ...init.headers,
     ...credential.authHeader,
   };

--- a/packages/web/src/package/ui/client/client.ts
+++ b/packages/web/src/package/ui/client/client.ts
@@ -120,10 +120,11 @@ export async function client<
   let urlResult = url as string;
 
   const credential = resolveCredential(options);
+  const isProjectScopedEndpoint = urlResult.includes('/projects/');
   if (
     credential.requiresExplicitProject &&
     credential.projectId === undefined &&
-    urlResult.includes('/projects/')
+    isProjectScopedEndpoint
   ) {
     throw new HttpError('project_id_not_specified');
   }

--- a/testapps/react/.gitignore
+++ b/testapps/react/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+/public/tolgee-in-context-tools.umd.min.js

--- a/testapps/react/src/inContextUrl.ts
+++ b/testapps/react/src/inContextUrl.ts
@@ -1,0 +1,9 @@
+// Dev only: point the in-context editor UMD at a local build instead of the CDN, so unpublished @tolgee/web changes
+// (e.g. OAuth Bearer support) can be exercised in-context. This MUST run before App.tsx, which builds the Tolgee
+// instance at module scope — the loader reads window.__TOLGEE_IN_CONTEXT_URL__ during that init, so setting it later
+// (a plain statement in main.tsx, after the hoisted App import) is too late. Imported first in main.tsx.
+if (import.meta.env.VITE_APP_IN_CONTEXT_URL) {
+  (
+    window as unknown as { __TOLGEE_IN_CONTEXT_URL__?: string }
+  ).__TOLGEE_IN_CONTEXT_URL__ = import.meta.env.VITE_APP_IN_CONTEXT_URL;
+}

--- a/testapps/react/src/main.tsx
+++ b/testapps/react/src/main.tsx
@@ -1,15 +1,9 @@
+// Must be first: sets the in-context loader override before App.tsx builds the Tolgee instance at module scope.
+import './inContextUrl';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App.tsx';
 import './style.css';
-
-// Dev only: load the in-context editor UMD from a local build (via VITE_APP_IN_CONTEXT_URL) instead of the CDN, so
-// unpublished @tolgee/web changes (e.g. OAuth Bearer support) can be exercised. Inert when the env var is unset.
-if (import.meta.env.VITE_APP_IN_CONTEXT_URL) {
-  (
-    window as unknown as { __TOLGEE_IN_CONTEXT_URL__?: string }
-  ).__TOLGEE_IN_CONTEXT_URL__ = import.meta.env.VITE_APP_IN_CONTEXT_URL;
-}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/testapps/react/src/main.tsx
+++ b/testapps/react/src/main.tsx
@@ -3,6 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { App } from './App.tsx';
 import './style.css';
 
+// Dev only: load the in-context editor UMD from a local build (via VITE_APP_IN_CONTEXT_URL) instead of the CDN, so
+// unpublished @tolgee/web changes (e.g. OAuth Bearer support) can be exercised. Inert when the env var is unset.
+if (import.meta.env.VITE_APP_IN_CONTEXT_URL) {
+  (
+    window as unknown as { __TOLGEE_IN_CONTEXT_URL__?: string }
+  ).__TOLGEE_IN_CONTEXT_URL__ = import.meta.env.VITE_APP_IN_CONTEXT_URL;
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Part of the cross-repo OAuth 2.1 work (see tolgee/tolgee-platform#3849). Adds the minimal path for `@tolgee/web` to accept an OAuth access token so the browser extension can drive in-context editing without a PAK.

## Changes
- `@tolgee/web`: accept an OAuth access token as a `Bearer` alternative to `X-API-Key` (client + DevBackend); `projectId` becomes required with a bearer token, like a PAT.
- Read the injected token live so long-open pages stay authenticated across refresh.
- Let the browser extension supply the OAuth project id.
- Warn when `projectId` is missing, and support loading a local in-context editor build via `window.__TOLGEE_IN_CONTEXT_URL__` for dev.
- React testapp: apply the in-context URL override before Tolgee initializes.

Draft — depends on the platform and chrome-plugin branches of the same name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 bearer-token authentication alongside API keys.
  * Added project-scoped authentication with clear project ID requirements.
  * Browser extensions now support session-based credentials and token rotation.
  * Added trusted development overrides for in-context editor scripts.
  * Added an option to open the browser extension from authentication errors.
  * Added SDK identification headers for API-key requests.
* **Bug Fixes**
  * Improved credential selection, fallback handling, and cleanup.
  * Invalid API key project data is now rejected safely.
  * Error messages clarify missing credentials and project IDs.
* **Tests**
  * Expanded authentication, project validation, browser extension, session cleanup, and in-context loading coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->