### PR TITLE
fix: repair E2E CI (local lerna + relink @tolgee/ngx for the testapp)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Update version with lerna
         run: |
-          lerna version prerelease --yes --conventional-prerelease --preid "test.$(git ls-files -s packages | git hash-object --stdin)" --ignore-scripts \
+          pnpm exec lerna version prerelease --yes --conventional-prerelease --preid "test.$(git ls-files -s packages | git hash-object --stdin)" --ignore-scripts \
             --force-publish --no-push --no-git-tag-version --exact
 
       - name: Set TOLGEE_UI_VERSION
@@ -177,7 +177,7 @@ jobs:
 
       - name: Update version with lerna
         run: |
-          lerna version prerelease --yes --conventional-prerelease --preid "test.$(git ls-files -s packages | git hash-object --stdin)" --ignore-scripts \
+          pnpm exec lerna version prerelease --yes --conventional-prerelease --preid "test.$(git ls-files -s packages | git hash-object --stdin)" --ignore-scripts \
             --force-publish --no-push --no-git-tag-version --exact
 
       - name: Remove 'workspace' field from package.json

--- a/scripts/customLinks.js
+++ b/scripts/customLinks.js
@@ -1,4 +1,4 @@
-const { existsSync, rmSync, symlinkSync } = require('fs');
+const { existsSync, lstatSync, rmSync, symlinkSync, unlinkSync } = require('fs');
 const { join, resolve, relative } = require('path');
 const { execSync } = require('child_process');
 
@@ -6,32 +6,49 @@ const { execSync } = require('child_process');
 // so when a library uses separate package.json in the build folder,
 // we need to redirect symlink directly there
 
-const target = './packages/ngx/dist/ngx-tolgee';
-const locationDir = './testapps/ngx/node_modules/@tolgee';
+// Resolve paths from the repo root (this script's parent dir), not the caller's CWD, so it works whether it's run from
+// the repo root (packages/ngx build) or from the ngx testapp's own build.
+const repoRoot = resolve(__dirname, '..');
+const target = join(repoRoot, 'packages/ngx/dist/ngx-tolgee');
+const locationDir = join(repoRoot, 'testapps/ngx/node_modules/@tolgee');
 const location = join(locationDir, 'ngx');
 
 // Use junction on Windows (doesn't require admin), symlink on Unix
-const absoluteTarget = resolve(target);
-const absoluteLocation = resolve(location);
+const absoluteTarget = target;
+const absoluteLocation = location;
 
-// Remove existing symlink/junction if it exists
-rmSync(location, { recursive: true, force: true });
-
-if (process.platform === 'win32') {
-  // Use mklink /J for junction on Windows
-  if (existsSync(absoluteTarget)) {
+// Only touch `location` when the local build output exists. In the E2E flow the testapp installs @tolgee/ngx from the
+// registry via npm and there is no local dist to link — removing it there would delete the installed package and break
+// the build, so leave whatever is already installed untouched.
+if (!existsSync(absoluteTarget)) {
+  // Drop a leftover link from a previous build: a symlink/junction now points at the missing dist (present to lstat but
+  // unresolvable), so it would shadow resolution. A real installed directory (the E2E npm flow) resolves and is kept.
+  let danglingLink = false;
+  try {
+    lstatSync(absoluteLocation);
+    danglingLink = !existsSync(absoluteLocation);
+  } catch {
+    // Nothing at that path — nothing to clean.
+  }
+  if (danglingLink) {
+    // Use unlink, not rmSync: rmSync follows the link, sees the missing target, and (with force) treats it as already
+    // gone, leaving the dangling link in place. Fall back to rmSync for a Windows junction unlink can't remove.
+    try {
+      unlinkSync(absoluteLocation);
+    } catch {
+      rmSync(absoluteLocation, { recursive: true, force: true });
+    }
+  }
+  console.warn(
+    `Warning: Target directory "${absoluteTarget}" does not exist. Skipping symlink creation; leaving any installed @tolgee/ngx in place. Run build first.`
+  );
+} else {
+  // Replace an existing symlink/junction (or a stale install) with a fresh link to the built library.
+  rmSync(location, { recursive: true, force: true });
+  if (process.platform === 'win32') {
+    // Use mklink /J for junction on Windows
     execSync(`mklink /J "${absoluteLocation}" "${absoluteTarget}"`);
   } else {
-    console.warn(
-      `Warning: Target directory "${absoluteTarget}" does not exist. Skipping symlink creation. Run build first.`
-    );
-  }
-} else {
-  if (existsSync(absoluteTarget)) {
     symlinkSync(relative(locationDir, target), location);
-  } else {
-    console.warn(
-      `Warning: Target directory "${absoluteTarget}" does not exist. Skipping symlink creation. Run build first.`
-    );
   }
 }

--- a/testapps/ngx/package.json
+++ b/testapps/ngx/package.json
@@ -6,7 +6,7 @@
     "develop": "sleep 10 && ng serve --configuration=stage",
     "start": "ng serve --configuration=stage",
     "startE2e": "ng serve --configuration=e2e",
-    "build": "ng build --configuration=production",
+    "build": "node ../../scripts/customLinks.js && ng build --configuration=production",
     "clean": "rm -rf build build-e2e dist dist-e2e lib .angular",
     "lint": "ng lint",
     "e2e": "ng e2e",


### PR DESCRIPTION
## Problem

E2E CI is red on every PR right now, for two unrelated reasons:

### 1. lerna crash
The `Update version with lerna` step invokes a bare `lerna`, which resolves to a **global** install (`/usr/local/lib/node_modules/lerna`). On the current runner that binary's `cli.js` is loaded as an ES module, so `__filename` is undefined and `import-local` crashes before lerna does anything:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at module.exports (…/lerna/node_modules/import-local/index.js:8)
    at file:///…/lerna/dist/cli.js
```

The repo's pinned local lerna (loaded as CommonJS) runs the exact same command fine.

**Fix:** run it through `pnpm exec` so the local `node_modules/lerna` is used.

### 2. `@tolgee/ngx-testapp` build can't resolve `@tolgee/ngx`

```
TS2307: Cannot find module '@tolgee/ngx' or its corresponding type declarations.
```

`@tolgee/ngx` builds to `packages/ngx/dist/ngx-tolgee`, then `scripts/customLinks.js` (run inside `@tolgee/ngx`'s build) symlinks it into `testapps/ngx/node_modules/@tolgee/ngx`. That symlink lives **outside** the package, so turbo never records it as an output. When `@tolgee/ngx#build` is a **cache hit**, its build script — and `customLinks.js` — is skipped, the symlink is missing, and the Angular testapp build fails. (It passed historically only on a cold cache.)

**Fix:** run `customLinks.js` from the testapp's own `build` script so the link is re-established whenever the testapp builds, independent of the `@tolgee/ngx` cache state; and resolve the script's paths from the repo root instead of the caller's CWD so it works from either location. turbo caching stays enabled.

## Notes
- Split out of the OAuth PR (#3531) since these are pre-existing CI issues unrelated to it. The lerna commit also appears there; it can be dropped from that PR once this merges.
- Reproduced locally: removing the `testapps/ngx/node_modules/@tolgee/ngx` symlink reproduces the exact `TS2307`, and the testapp `build` then self-heals the link and completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project linking so it works consistently regardless of the directory from which the command is run.
  * Prevented missing build targets from overwriting existing installations.
  * Ensured required link setup runs automatically before the Angular production build.

* **Chores**
  * Improved versioning command execution for more reliable development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->